### PR TITLE
Fix TLFamily property getter and editor usage hints (and more).

### DIFF
--- a/libgdtl/classes/tl_shaped_paragraph.gdns
+++ b/libgdtl/classes/tl_shaped_paragraph.gdns
@@ -4,6 +4,6 @@
 
 [resource]
 
-resource_name = "TLShapedString"
-class_name = "TLShapedString"
+resource_name = "TLShapedParagraph"
+class_name = "TLShapedParagraph"
 library = ExtResource( 1 )

--- a/libgdtl/libgdtl.gdnlib
+++ b/libgdtl/libgdtl.gdnlib
@@ -8,10 +8,20 @@ symbol_prefix="gdtl_"
 
 Windows.32="res://addons/libgdtl/bin/windows.x86/libgdtl.dll"
 Windows.64="res://addons/libgdtl/bin/windows.x86_64/libgdtl.dll"
+
 OSX="res://addons/libgdtl/bin/darwin.x86_64/libgdtl.dylib"
+
 X11.x86="res://addons/libgdtl/bin/linux.x86/libgdtl.so"
 X11.x86_64="res://addons/libgdtl/bin/linux.x86_64/libgdtl.so"
 X11.armv7="res://addons/libgdtl/bin/linux.armv7/libgdtl.so"
 X11.arm64="res://addons/libgdtl/bin/linux.arm64/libgdtl.so"
+
+Android.x86="res://addons/libgdtl/bin/android.x86/libgdtl.so"
+Android.x86_64="res://addons/libgdtl/bin/android.x86_64/libgdtl.so"
+Android.armv7="res://addons/libgdtl/bin/android.armv7/libgdtl.so"
+Android.arm64="res://addons/libgdtl/bin/android.arm64/libgdtl.so"
+
+iOS.x86_64="res://addons/libgdtl/bin/ios.x86_64/libgdtl.a"
+iOS.arm64="res://addons/libgdtl/bin/ios.arm64/libgdtl.a"
 
 [dependencies]

--- a/src/controls/tl_label.hpp
+++ b/src/controls/tl_label.hpp
@@ -161,6 +161,8 @@ public:
 	void set_base_font_size(int p_size);
 
 	TLLabel();
+
+	virtual ~TLLabel(){};
 };
 
 #ifdef GODOT_MODULE

--- a/src/controls/tl_line_edit.hpp
+++ b/src/controls/tl_line_edit.hpp
@@ -261,6 +261,8 @@ public:
 	void set_base_font_size(int p_size);
 
 	TLLineEdit();
+
+	virtual ~TLLineEdit(){};
 };
 
 #ifdef GODOT_MODULE

--- a/src/resources/tl_bitmap_font.hpp
+++ b/src/resources/tl_bitmap_font.hpp
@@ -75,7 +75,7 @@ public:
 	virtual void _draw_char(RID p_canvas_item, const Point2 p_pos, uint32_t p_codepoint, const Color p_modulate, int p_size) const override; //raw char for debug only, do not use
 	virtual void draw_glyph(RID p_canvas_item, const Point2 p_pos, uint32_t p_codepoint, const Color p_modulate, int p_size) const override;
 
-	virtual std::vector<hb_script_t> unicode_scripts_supported() const;
+	virtual std::vector<hb_script_t> unicode_scripts_supported() const override;
 
 	//GDNative methods
 	virtual bool load(String p_resource_path) override;

--- a/src/resources/tl_dynamic_font.hpp
+++ b/src/resources/tl_dynamic_font.hpp
@@ -154,7 +154,7 @@ public:
 	virtual void draw_glyph_outline(RID p_canvas_item, const Point2 p_pos, uint32_t p_codepoint, const Color p_modulate, int p_size) const override;
 	virtual Array get_glyph_outline(const Point2 p_pos, uint32_t p_codepoint, int p_size) const override;
 
-	virtual std::vector<hb_script_t> unicode_scripts_supported() const;
+	virtual std::vector<hb_script_t> unicode_scripts_supported() const override;
 
 	//GDNative methods
 	virtual bool load(String p_resource_path) override;

--- a/src/resources/tl_font_family.cpp
+++ b/src/resources/tl_font_family.cpp
@@ -439,7 +439,7 @@ bool TLFontFamily::_get(const StringName &p_name, Variant &r_ret) const {
 	String name = p_name;
 
 	Vector<String> tokens = name.split("/");
-	if ((tokens.size() >= 2) && (styles.count(tokens[0]))) {
+	if (tokens.size() >= 2) {
 		String style = tokens[0];
 		if (styles.count(style.to_upper()) > 0) {
 			if (tokens.size() == 2) {
@@ -483,19 +483,19 @@ void TLFontFamily::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (auto it = styles.begin(); it != styles.end(); ++it) {
 
 		for (int i = 0; i < it->second.main_chain.size(); i++) {
-			p_list->push_back(PropertyInfo(Variant::OBJECT, it->first.to_lower() + "/" + String::num_int64(i), PROPERTY_HINT_RESOURCE_TYPE, "TLFontFace", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_STORAGE));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, it->first.to_lower() + "/" + String::num_int64(i), PROPERTY_HINT_RESOURCE_TYPE, "TLFontFace"));
 		}
 
 		for (auto sit = it->second.linked_src_chain.begin(); sit != it->second.linked_src_chain.end(); ++sit) {
 			for (int i = 0; i < sit->second.size(); i++) {
 				char tag[5] = "";
 				hb_tag_to_string(hb_script_to_iso15924_tag(sit->first), tag);
-				p_list->push_back(PropertyInfo(Variant::OBJECT, it->first.to_lower() + "/script/" + tag + "/" + String::num_int64(i), PROPERTY_HINT_RESOURCE_TYPE, "TLFontFace", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_STORAGE));
+				p_list->push_back(PropertyInfo(Variant::OBJECT, it->first.to_lower() + "/script/" + tag + "/" + String::num_int64(i), PROPERTY_HINT_RESOURCE_TYPE, "TLFontFace"));
 			}
 		}
 		for (auto sit = it->second.linked_lang_chain.begin(); sit != it->second.linked_lang_chain.end(); ++sit) {
 			for (int i = 0; i < sit->second.size(); i++) {
-				p_list->push_back(PropertyInfo(Variant::OBJECT, it->first.to_lower() + "/lang/" + hb_language_to_string(sit->first) + "/" + String::num_int64(i), PROPERTY_HINT_RESOURCE_TYPE, "TLFontFace", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_STORAGE));
+				p_list->push_back(PropertyInfo(Variant::OBJECT, it->first.to_lower() + "/lang/" + hb_language_to_string(sit->first) + "/" + String::num_int64(i), PROPERTY_HINT_RESOURCE_TYPE, "TLFontFace"));
 			}
 		}
 	}
@@ -568,7 +568,7 @@ Variant TLFontFamily::_get(String p_name) const {
 	String name = p_name;
 
 	PoolStringArray tokens = name.split("/");
-	if ((tokens.size() >= 2) && (styles.count(tokens[0]))) {
+	if (tokens.size() >= 2) {
 		String style = tokens[0];
 		if (styles.count(style.to_upper()) > 0) {
 			if (tokens.size() == 2) {

--- a/src/resources/tl_shaped_paragraph.cpp
+++ b/src/resources/tl_shaped_paragraph.cpp
@@ -188,7 +188,16 @@ float TLShapedParagraph::get_line_spacing() const {
 
 void TLShapedParagraph::set_string(Ref<TLShapedAttributedString> p_string) {
 
-	if (ctx != p_string) {
+	if (p_string.is_null()) {
+#ifdef GODOT_MODULE
+		ctx = Ref<TLShapedAttributedString>();
+		ctx.instance();
+#else
+		ctx = Ref<TLShapedAttributedString>::__internal_constructor(TLShapedAttributedString::_new());
+#endif
+		ctx->connect("string_changed", this, "_update_paragraph");
+		_update_paragraph();
+	} else if (ctx != p_string) {
 		ctx->disconnect("string_changed", this, "_update_paragraph");
 		ctx = p_string;
 		ctx->connect("string_changed", this, "_update_paragraph");


### PR DESCRIPTION
Fix `TLFamily` property getter and editor usage hints.
Fix some compilation warnings.
Fix `TLShapedParagraph` GDNative definition and null string dereferencing in `set_string`.

Fixes #4