### PR TITLE
Propagate font face/family changes to the shaped strings and then to controls.

### DIFF
--- a/src/controls/tl_label.cpp
+++ b/src/controls/tl_label.cpp
@@ -415,6 +415,11 @@ Ref<TLFontFamily> TLLabel::get_base_font() const {
 	return s_paragraph->get_base_font();
 }
 
+void TLLabel::_font_changed() {
+	_lines_dirty = true;
+	update();
+}
+
 void TLLabel::set_base_font(const Ref<TLFontFamily> p_font) {
 
 	s_paragraph->set_base_font(p_font);
@@ -576,6 +581,8 @@ int TLLabel::get_total_character_count() const {
 
 void TLLabel::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("_font_changed"), &TLLabel::_font_changed);
+
 	ClassDB::bind_method(D_METHOD("set_align", "align"), &TLLabel::set_align);
 	ClassDB::bind_method(D_METHOD("get_align"), &TLLabel::get_align);
 	ClassDB::bind_method(D_METHOD("set_valign", "valign"), &TLLabel::set_valign);
@@ -648,6 +655,8 @@ void TLLabel::_bind_methods() {
 
 void TLLabel::_register_methods() {
 
+	register_method("_font_changed", &TLLabel::_font_changed);
+
 	register_method("set_align", &TLLabel::set_align);
 	register_method("get_align", &TLLabel::get_align);
 	register_method("set_valign", &TLLabel::set_valign);
@@ -719,6 +728,7 @@ TLLabel::TLLabel() {
 void TLLabel::_init() {
 
 	s_paragraph.instance();
+	s_paragraph->connect("string_changed", this, "_font_changed");
 
 	base_direction = TEXT_DIRECTION_AUTO;
 	ot_features = "";

--- a/src/controls/tl_label.hpp
+++ b/src/controls/tl_label.hpp
@@ -105,6 +105,8 @@ public:
 #endif
 	void _init();
 
+	void _font_changed();
+
 	virtual Size2 get_minimum_size() const;
 
 	void set_align(int p_align);

--- a/src/controls/tl_line_edit.cpp
+++ b/src/controls/tl_line_edit.cpp
@@ -1171,6 +1171,10 @@ Ref<TLFontFamily> TLLineEdit::get_base_font() const {
 	return line->get_base_font();
 }
 
+void TLLineEdit::_font_changed() {
+	update();
+}
+
 void TLLineEdit::set_base_font(const Ref<TLFontFamily> p_font) {
 
 	line->set_base_font(p_font);
@@ -1664,6 +1668,7 @@ void TLLineEdit::_create_undo_state() {
 
 void TLLineEdit::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("_font_changed"), &TLLineEdit::_font_changed);
 	ClassDB::bind_method(D_METHOD("_text_changed"), &TLLineEdit::_text_changed);
 	ClassDB::bind_method(D_METHOD("_toggle_draw_caret"), &TLLineEdit::_toggle_draw_caret);
 
@@ -1772,6 +1777,7 @@ void TLLineEdit::_bind_methods() {
 
 void TLLineEdit::_register_methods() {
 
+	register_method("_font_changed", &TLLineEdit::_font_changed);
 	register_method("_text_changed", &TLLineEdit::_text_changed);
 	register_method("_toggle_draw_caret", &TLLineEdit::_toggle_draw_caret);
 
@@ -1876,6 +1882,7 @@ TLLineEdit::TLLineEdit() {
 
 void TLLineEdit::_init() {
 	line.instance();
+	line->connect("string_changed", this, "_font_changed");
 
 	base_direction = TEXT_DIRECTION_AUTO;
 	last_input_direction = TEXT_DIRECTION_AUTO;

--- a/src/controls/tl_line_edit.hpp
+++ b/src/controls/tl_line_edit.hpp
@@ -136,6 +136,7 @@ private:
 	Timer *caret_blink_timer;
 
 	Ref<TLShapedString> line;
+	void _font_changed();
 	void _text_reshape();
 	void _emit_text_change();
 	bool expand_to_text_length;

--- a/src/resources/tl_bitmap_font.cpp
+++ b/src/resources/tl_bitmap_font.cpp
@@ -342,12 +342,14 @@ void TLBitmapFontFace::clear_cache() {
 
 void TLBitmapFontFace::set_font_path(String p_resource_path) {
 
-	path = p_resource_path;
-	load(p_resource_path);
+	if (path != p_resource_path) {
+		load(p_resource_path);
+	}
 }
 
 bool TLBitmapFontFace::load(String p_resource_path) {
 
+	path = p_resource_path;
 	if (loaded) {
 		//unload existing
 		clear_cache();
@@ -359,6 +361,7 @@ bool TLBitmapFontFace::load(String p_resource_path) {
 	file.instance();
 	if (file->open(p_resource_path, File::READ) != Error::OK) {
 		ERR_PRINTS("Can't open bitmap font file: \"" + p_resource_path + "\"");
+		emit_signal(_CHANGED);
 		return false;
 	}
 
@@ -428,6 +431,7 @@ bool TLBitmapFontFace::load(String p_resource_path) {
 					ERR_PRINTS("Can't load bitmap font texture: \"" + file_name + "\"");
 					clear_cache();
 					file->close();
+					emit_signal(_CHANGED);
 					return false;
 				} else {
 					tex->set_flags(txt_flags);
@@ -499,6 +503,7 @@ bool TLBitmapFontFace::load(String p_resource_path) {
 
 	file->close();
 	loaded = true;
+	emit_signal(_CHANGED);
 	return loaded;
 }
 
@@ -553,6 +558,7 @@ void TLBitmapFontFace::set_texture_flags(int p_flags) {
 				if (!tex.is_null())
 					tex->set_flags(txt_flags);
 			}
+			emit_signal(_CHANGED);
 		}
 	}
 }

--- a/src/resources/tl_dynamic_font.cpp
+++ b/src/resources/tl_dynamic_font.cpp
@@ -977,7 +977,9 @@ Array TLDynamicFontFace::get_glyph_outline(const Point2 p_pos, uint32_t p_codepo
 
 void TLDynamicFontFace::set_font_path(String p_resource_path) {
 
-	load(p_resource_path);
+	if (path != p_resource_path) {
+		load(p_resource_path);
+	}
 }
 
 bool TLDynamicFontFace::load(String p_resource_path) {
@@ -987,6 +989,7 @@ bool TLDynamicFontFace::load(String p_resource_path) {
 		delete it->second;
 	}
 	sizes.clear();
+	emit_signal(_CHANGED);
 	return true;
 }
 
@@ -1072,9 +1075,12 @@ double TLDynamicFontFace::get_height(int p_size) const {
 
 void TLDynamicFontFace::set_texture_flags(int p_flags) {
 
-	txt_flags = p_flags;
-	for (auto it = sizes.begin(); it != sizes.end(); ++it) {
-		it->second->set_texture_flags(p_flags);
+	if (txt_flags != p_flags) {
+		txt_flags = p_flags;
+		for (auto it = sizes.begin(); it != sizes.end(); ++it) {
+			it->second->set_texture_flags(p_flags);
+		}
+		emit_signal(_CHANGED);
 	}
 }
 
@@ -1085,9 +1091,12 @@ int TLDynamicFontFace::get_texture_flags() const {
 
 void TLDynamicFontFace::set_hinting(int p_hinting) {
 
-	hinting = (DynamicFaceHinting)p_hinting;
-	for (auto it = sizes.begin(); it != sizes.end(); ++it) {
-		it->second->set_hinting(p_hinting);
+	if (hinting != (DynamicFaceHinting)p_hinting) {
+		hinting = (DynamicFaceHinting)p_hinting;
+		for (auto it = sizes.begin(); it != sizes.end(); ++it) {
+			it->second->set_hinting(p_hinting);
+		}
+		emit_signal(_CHANGED);
 	}
 }
 
@@ -1098,9 +1107,12 @@ int TLDynamicFontFace::get_hinting() const {
 
 void TLDynamicFontFace::set_force_autohinter(bool p_force) {
 
-	force_autohinter = p_force;
-	for (auto it = sizes.begin(); it != sizes.end(); ++it) {
-		it->second->set_force_autohinter(p_force);
+	if (force_autohinter != p_force) {
+		force_autohinter = p_force;
+		for (auto it = sizes.begin(); it != sizes.end(); ++it) {
+			it->second->set_force_autohinter(p_force);
+		}
+		emit_signal(_CHANGED);
 	}
 }
 
@@ -1111,9 +1123,12 @@ bool TLDynamicFontFace::get_force_autohinter() const {
 
 void TLDynamicFontFace::set_oversampling(float p_oversampling) {
 
-	oversampling = p_oversampling;
-	for (auto it = sizes.begin(); it != sizes.end(); ++it) {
-		it->second->set_oversampling(p_oversampling);
+	if (oversampling != p_oversampling) {
+		oversampling = p_oversampling;
+		for (auto it = sizes.begin(); it != sizes.end(); ++it) {
+			it->second->set_oversampling(p_oversampling);
+		}
+		emit_signal(_CHANGED);
 	}
 }
 

--- a/src/resources/tl_font.cpp
+++ b/src/resources/tl_font.cpp
@@ -141,8 +141,6 @@ void TLFontFace::draw_glyph_outline(RID p_canvas_item, const Point2 p_pos, uint3
 }
 
 Array TLFontFace::get_glyph_outline(const Point2 p_pos, uint32_t p_codepoint, int p_size) const {
-
-	WARN_PRINTS("Not implemented, pure virtual function call!")
 	return Array();
 }
 
@@ -153,7 +151,6 @@ float TLFontFace::get_glyph_scale(int p_size) const {
 
 hb_font_t *TLFontFace::get_hb_font(int p_size) const {
 
-	WARN_PRINTS("Not implemented, pure virtual function call!")
 	return NULL;
 }
 
@@ -179,25 +176,21 @@ Array TLFontFace::_unicode_scripts_supported() const {
 
 std::vector<hb_script_t> TLFontFace::unicode_scripts_supported() const {
 
-	WARN_PRINTS("Not implemented, pure virtual function call!")
 	return std::vector<hb_script_t>();
 }
 
 double TLFontFace::get_ascent(int p_size) const {
 
-	WARN_PRINTS("Not implemented, pure virtual function call!")
 	return 0.0f;
 }
 
 double TLFontFace::get_descent(int p_size) const {
 
-	WARN_PRINTS("Not implemented, pure virtual function call!")
 	return 0.0f;
 }
 
 double TLFontFace::get_height(int p_size) const {
 
-	WARN_PRINTS("Not implemented, pure virtual function call!")
 	return 0.0f;
 }
 
@@ -208,18 +201,17 @@ void TLFontFace::set_texture_flags(int p_flags) {
 
 int TLFontFace::get_texture_flags() const {
 
-	WARN_PRINTS("Not implemented, pure virtual function call!")
 	return 0;
 }
 
 int TLFontFace::get_base_size() const {
 
-	WARN_PRINTS("Not implemented, pure virtual function call!")
 	return 0;
 }
 
 void TLFontFace::set_font_path(String p_resource_path) {
 
+	WARN_PRINTS("Not implemented, pure virtual function call!")
 	path = p_resource_path;
 }
 

--- a/src/resources/tl_font_family.hpp
+++ b/src/resources/tl_font_family.hpp
@@ -96,6 +96,7 @@ class TLFontFamily : public Resource {
 
 protected:
 	std::map<String, StyleData> styles;
+	std::map<Ref<TLFontFace>, int> _ref_count;
 
 public:
 	TLFontFamily();
@@ -118,6 +119,10 @@ public:
 	void add_face_unlinked(String p_style, Ref<TLFontFace> p_ref);
 	void add_face_for_script(String p_style, Ref<TLFontFace> p_ref, String p_script);
 	void add_face_for_language(String p_style, Ref<TLFontFace> p_ref, String p_lang);
+
+	void _font_changed();
+	void _inc_ref(Ref<TLFontFace> &p_font);
+	void _dec_ref(Ref<TLFontFace> &p_font);
 
 #ifdef GODOT_MODULE
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/src/resources/tl_shaped_attributed_string.hpp
+++ b/src/resources/tl_shaped_attributed_string.hpp
@@ -61,6 +61,9 @@ protected:
 	Map<int, Map<TextAttribute, Variant> > format_attributes;
 	Map<int, Map<TextAttribute, Variant> > style_attributes;
 
+	virtual void _disconnect_fonts();
+	virtual void _reconnect_fonts();
+
 	virtual bool _compare_attributes(const Map<TextAttribute, Variant> &p_first, const Map<TextAttribute, Variant> &p_second) const;
 	virtual void _ensure_break(int64_t p_key, Map<int, Map<TextAttribute, Variant> > &p_attributes);
 	virtual void _optimize_attributes(Map<int, Map<TextAttribute, Variant> > &p_attributes);

--- a/src/resources/tl_shaped_string.cpp
+++ b/src/resources/tl_shaped_string.cpp
@@ -544,7 +544,13 @@ void TLShapedString::_shape_substring(TLShapedString *p_ref, int64_t p_start, in
 
 	p_ref->base_direction = base_direction;
 	p_ref->para_direction = para_direction;
+	if (p_ref->base_font.is_valid() && p_ref->base_font->is_connected(_CHANGED, p_ref, "_font_changed")) {
+		p_ref->base_font->disconnect(_CHANGED, p_ref, "_font_changed");
+	}
 	p_ref->base_font = base_font;
+	if (p_ref->base_font.is_valid() && !p_ref->base_font->is_connected(_CHANGED, p_ref, "_font_changed")) {
+		p_ref->base_font->connect(_CHANGED, p_ref, "_font_changed");
+	}
 	p_ref->base_style = base_style;
 	p_ref->base_size = base_size;
 
@@ -808,6 +814,11 @@ void TLShapedString::set_base_direction(int p_base_direction) {
 	}
 }
 
+void TLShapedString::_font_changed() {
+	_clear_visual();
+	emit_signal("string_changed");
+}
+
 Ref<TLFontFamily> TLShapedString::get_base_font() const {
 
 	return base_font;
@@ -820,7 +831,14 @@ void TLShapedString::set_base_font(const Ref<TLFontFamily> p_font) {
 		return;
 	}
 	if (base_font != p_font) {
+		if (base_font.is_valid() && base_font->is_connected(_CHANGED, this, "_font_changed")) {
+			base_font->disconnect(_CHANGED, this, "_font_changed");
+		}
 		base_font = p_font;
+		if (base_font.is_valid() && !base_font->is_connected(_CHANGED, this, "_font_changed")) {
+			base_font->connect(_CHANGED, this, "_font_changed");
+		}
+
 		_clear_visual();
 		emit_signal("string_changed");
 	}
@@ -1173,6 +1191,9 @@ Ref<TLShapedString> TLShapedString::substr(int64_t p_start, int64_t p_end, int p
 	ret->base_direction = base_direction;
 	ret->para_direction = para_direction;
 	ret->base_font = base_font;
+	if (ret->base_font.is_valid()) {
+		ret->base_font->connect(_CHANGED, ret.ptr(), "_font_changed");
+	}
 	ret->base_style = base_style;
 	ret->base_size = base_size;
 	ret->language = language;
@@ -2795,7 +2816,13 @@ void TLShapedString::copy_properties(Ref<TLShapedString> p_source) {
 	base_direction = p_source->base_direction;
 	language = p_source->language;
 	font_features = p_source->font_features;
+	if (base_font.is_valid() && base_font->is_connected(_CHANGED, this, "_font_changed")) {
+		base_font->disconnect(_CHANGED, this, "_font_changed");
+	}
 	base_font = p_source->base_font;
+	if (base_font.is_valid() && !base_font->is_connected(_CHANGED, this, "_font_changed")) {
+		base_font->connect(_CHANGED, this, "_font_changed");
+	}
 	base_size = p_source->base_size;
 	base_style = p_source->base_style;
 
@@ -2806,6 +2833,8 @@ void TLShapedString::copy_properties(Ref<TLShapedString> p_source) {
 #ifdef GODOT_MODULE
 
 void TLShapedString::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("_font_changed"), &TLShapedString::_font_changed);
 
 	ClassDB::bind_method(D_METHOD("copy_properties", "source"), &TLShapedString::copy_properties);
 
@@ -2956,6 +2985,8 @@ void TLShapedString::_bind_methods() {
 #else
 
 void TLShapedString::_register_methods() {
+
+	register_method("_font_changed", &TLShapedString::_font_changed);
 
 	register_method("copy_properties", &TLShapedString::copy_properties);
 

--- a/src/resources/tl_shaped_string.hpp
+++ b/src/resources/tl_shaped_string.hpp
@@ -384,6 +384,8 @@ public:
 	int64_t next_safe_bound(int64_t p_offset) const;
 	int64_t prev_safe_bound(int64_t p_offset) const;
 
+	void _font_changed();
+
 #ifdef GODOT_MODULE
 	static void _bind_methods();
 #else

--- a/src/tl_core.hpp
+++ b/src/tl_core.hpp
@@ -21,6 +21,9 @@ namespace godot {};
 #define GODOT_SUBCLASS GDCLASS
 #define GLOBAL_CONST(m_text) m_text
 
+#include "core/core_string_names.h"
+#define _CHANGED CoreStringNames::get_singleton()->changed
+
 #else
 
 #include <nativescript/godot_nativescript.h>
@@ -29,6 +32,7 @@ namespace godot {};
 #include <OS.hpp>
 #include <Reference.hpp>
 #include <Resource.hpp>
+#define _CHANGED "changed"
 
 #define GLOBAL_CONST(m_text) GlobalConstants::m_text
 #define memnew(type) type::_new()


### PR DESCRIPTION
Fixes #4 (second issue - https://github.com/bruvzg/godot_tl/issues/4#issuecomment-546640649)