### PR TITLE
Fix default platform for X11 in gdnative

### DIFF
--- a/libgdtl/libgdtl.gdnlib
+++ b/libgdtl/libgdtl.gdnlib
@@ -11,8 +11,8 @@ Windows.64="res://addons/libgdtl/bin/windows.x86_64/libgdtl.dll"
 
 OSX="res://addons/libgdtl/bin/darwin.x86_64/libgdtl.dylib"
 
-X11.x86="res://addons/libgdtl/bin/linux.x86/libgdtl.so"
-X11.x86_64="res://addons/libgdtl/bin/linux.x86_64/libgdtl.so"
+X11.32="res://addons/libgdtl/bin/linux.x86/libgdtl.so"
+X11.64="res://addons/libgdtl/bin/linux.x86_64/libgdtl.so"
 X11.armv7="res://addons/libgdtl/bin/linux.armv7/libgdtl.so"
 X11.arm64="res://addons/libgdtl/bin/linux.arm64/libgdtl.so"
 


### PR DESCRIPTION
Plugin can't be loaded by default without this change