### PR TITLE
Add editor inspector plugin for TLFontFamily.

### DIFF
--- a/src/SCsub
+++ b/src/SCsub
@@ -27,7 +27,8 @@ sources = [
 
 if env['tools']:
 	sources += [
-		'tools/tl_editor_node.cpp'
+		'tools/tl_editor_node.cpp',
+		'tools/tl_font_family_edit.cpp'
 	]
 
 env_godot_tl.Append(CPPPATH=['.', '../subprojects/graphite2/include', '../subprojects/harfbuzz/src', '../subprojects/icu4c/source/common', '#thirdparty/freetype/include', '#thirdparty/nanosvg/'])

--- a/src/controls/tl_label.cpp
+++ b/src/controls/tl_label.cpp
@@ -702,7 +702,7 @@ void TLLabel::_register_methods() {
 	register_property<TLLabel, int>("align", &TLLabel::set_align, &TLLabel::get_align, ALIGN_LEFT, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, String("Left,Center,Right,Fill"));
 	register_property<TLLabel, int>("valign", &TLLabel::set_valign, &TLLabel::get_valign, VALIGN_TOP, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, String("Top,Center,Bottom,Fill"));
 
-	register_property<TLLabel, Ref<TLFontFamily> >("base_font", &TLLabel::set_base_font, &TLLabel::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
+	register_property<TLLabel, Ref<TLFontFamily> >("base_font", &TLLabel::set_base_font, &TLLabel::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_NOEDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
 	register_property<TLLabel, String>("base_font_style", &TLLabel::set_base_font_style, &TLLabel::get_base_font_style, String("Regular"));
 	register_property<TLLabel, int>("base_font_size", &TLLabel::set_base_font_size, &TLLabel::get_base_font_size, 12);
 

--- a/src/controls/tl_line_edit.cpp
+++ b/src/controls/tl_line_edit.cpp
@@ -1842,7 +1842,7 @@ void TLLineEdit::_register_methods() {
 	register_property<TLLineEdit, String>("text", &TLLineEdit::set_text, &TLLineEdit::get_text, String(), GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_MULTILINE_TEXT, String(""));
 	register_property<TLLineEdit, int>("align", &TLLineEdit::set_align, &TLLineEdit::get_align, ALIGN_LEFT, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, String("Left,Center,Right,Fill"));
 
-	register_property<TLLineEdit, Ref<TLFontFamily> >("base_font", &TLLineEdit::set_base_font, &TLLineEdit::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
+	register_property<TLLineEdit, Ref<TLFontFamily> >("base_font", &TLLineEdit::set_base_font, &TLLineEdit::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_NOEDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
 	register_property<TLLineEdit, String>("base_font_style", &TLLineEdit::set_base_font_style, &TLLineEdit::get_base_font_style, String("Regular"));
 	register_property<TLLineEdit, int>("base_font_size", &TLLineEdit::set_base_font_size, &TLLineEdit::get_base_font_size, 12);
 

--- a/src/resources/tl_font_family.hpp
+++ b/src/resources/tl_font_family.hpp
@@ -104,8 +104,15 @@ public:
 
 	void _init();
 
+	void add_style(String p_style);
 	void remove_style(String p_style);
 	bool has_style(String p_style) const;
+
+	void add_script(String p_style, String p_script);
+	void remove_script(String p_style, String p_script);
+
+	void add_language(String p_style, String p_lang);
+	void remove_language(String p_style, String p_lang);
 
 	TLFontFallbackIterator get_face(String p_style) const;
 	TLFontFallbackIterator get_face_for_script(String p_style, hb_script_t p_script) const;

--- a/src/resources/tl_shaped_paragraph.cpp
+++ b/src/resources/tl_shaped_paragraph.cpp
@@ -347,7 +347,7 @@ void TLShapedParagraph::_register_methods() {
 
 	register_method("set_string", &TLShapedParagraph::set_string);
 	register_method("get_string", &TLShapedParagraph::get_string);
-	register_property<TLShapedParagraph, Ref<TLShapedAttributedString> >("string", &TLShapedParagraph::set_string, &TLShapedParagraph::get_string, Ref<TLShapedAttributedString>(), GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLShapedAttributedString"));
+	register_property<TLShapedParagraph, Ref<TLShapedAttributedString> >("string", &TLShapedParagraph::set_string, &TLShapedParagraph::get_string, Ref<TLShapedAttributedString>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_NOEDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLShapedAttributedString"));
 
 	register_method("set_brk_flags", &TLShapedParagraph::set_brk_flags);
 	register_method("get_brk_flags", &TLShapedParagraph::get_brk_flags);

--- a/src/resources/tl_shaped_string.cpp
+++ b/src/resources/tl_shaped_string.cpp
@@ -3117,7 +3117,7 @@ void TLShapedString::_register_methods() {
 
 	register_property<TLShapedString, int>("base_direction", &TLShapedString::set_base_direction, &TLShapedString::get_base_direction, TEXT_DIRECTION_AUTO, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, String("LTR,RTL,Locale,Auto"));
 	register_property<TLShapedString, String>("text", &TLShapedString::set_text, &TLShapedString::get_text, String());
-	register_property<TLShapedString, Ref<TLFontFamily> >("base_font", &TLShapedString::set_base_font, &TLShapedString::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
+	register_property<TLShapedString, Ref<TLFontFamily> >("base_font", &TLShapedString::set_base_font, &TLShapedString::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_NOEDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
 	register_property<TLShapedString, String>("base_font_style", &TLShapedString::set_base_font_style, &TLShapedString::get_base_font_style, String("Regular"));
 	register_property<TLShapedString, int>("base_font_size", &TLShapedString::set_base_font_size, &TLShapedString::get_base_font_size, 12);
 	register_property<TLShapedString, String>("features", &TLShapedString::set_features, &TLShapedString::get_features, String());

--- a/src/tools/tl_editor_node.cpp
+++ b/src/tools/tl_editor_node.cpp
@@ -7,6 +7,7 @@
 
 #include "icons/icons.gen.h"
 #include "tl_editor_node.h"
+#include "tl_font_family_edit.hpp"
 
 TLEditorNode *TLEditorNode::singleton = NULL;
 
@@ -46,6 +47,11 @@ TLEditorNode::TLEditorNode(EditorNode *p_editor) {
 			type_icons[tl_icons_names[i]] = icon; //TL*
 		}
 	}
+
+	Ref<EditorInspectorPluginTLFontFamily> inspector_plugin;
+	inspector_plugin.instance();
+
+	EditorInspector::add_inspector_plugin(inspector_plugin);
 };
 
 TLEditorNode::~TLEditorNode() {

--- a/src/tools/tl_font_family_edit.cpp
+++ b/src/tools/tl_font_family_edit.cpp
@@ -1,0 +1,96 @@
+/*************************************************************************/
+/*  tl_font_family_edit.cpp                                              */
+/*************************************************************************/
+
+#include "tl_font_family_edit.hpp"
+
+bool EditorInspectorPluginTLFontFamily::can_handle(Object *p_object) {
+
+	return Object::cast_to<TLFontFamily>(p_object) != NULL;
+}
+
+void EditorInspectorPluginTLFontFamily::parse_begin(Object *p_object) {
+	//NOP
+}
+
+bool EditorInspectorPluginTLFontFamily::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage) {
+	Ref<TLFontFamily> ff = Ref<TLFontFamily>(Object::cast_to<TLFontFamily>(p_object));
+	if (p_path == "_new_style") {
+		HBoxContainer *hbox = memnew(HBoxContainer);
+		LineEdit *new_name = memnew(LineEdit);
+		new_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		new_name->set_placeholder("Style name");
+		hbox->add_child(new_name);
+		ButtonAddStyle *new_btn = memnew(ButtonAddStyle);
+		new_btn->set_ff(ff);
+		new_btn->set_ctl(new_name);
+		new_btn->set_text("Add style");
+		hbox->add_child(new_btn);
+		add_custom_control(hbox);
+		return true;
+	}
+	Vector<String> tokens = p_path.split("/");
+	if (tokens.size() == 2) {
+		if (tokens[1] == "_remove_style") {
+			ButtonDelStyle *rem_btn = memnew(ButtonDelStyle);
+			rem_btn->set_text("Remove \"" + tokens[0] + "\" style");
+			rem_btn->set_ff(ff);
+			rem_btn->set_sname(tokens[0]);
+			add_custom_control(rem_btn);
+			return true;
+		} else if (tokens[1] == "_add_lang") {
+			HBoxContainer *hbox = memnew(HBoxContainer);
+			LineEdit *new_name = memnew(LineEdit);
+			new_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			new_name->set_max_length(4);
+			new_name->set_placeholder("ISO script code");
+			hbox->add_child(new_name);
+			ButtonAddLang *new_btn = memnew(ButtonAddLang);
+			new_btn->set_ff(ff);
+			new_btn->set_sname(tokens[0]);
+			new_btn->set_ctl(new_name);
+			new_btn->set_text("Add language");
+			hbox->add_child(new_btn);
+			add_custom_control(hbox);
+			return true;
+		} else if (tokens[1] == "_add_script") {
+			HBoxContainer *hbox = memnew(HBoxContainer);
+			LineEdit *new_name = memnew(LineEdit);
+			new_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			new_name->set_max_length(4);
+			new_name->set_placeholder("ISO language code");
+			hbox->add_child(new_name);
+			ButtonAddScript *new_btn = memnew(ButtonAddScript);
+			new_btn->set_ff(ff);
+			new_btn->set_sname(tokens[0]);
+			new_btn->set_ctl(new_name);
+			new_btn->set_text("Add script");
+			hbox->add_child(new_btn);
+			add_custom_control(hbox);
+			return true;
+		}
+	} else if (tokens.size() == 4) {
+		if (tokens[3] == "_remove_script" && tokens[1] == "script") {
+			ButtonDelScript *rem_btn = memnew(ButtonDelScript);
+			rem_btn->set_text("Remove \"" + tokens[2] + "\" script");
+			rem_btn->set_ff(ff);
+			rem_btn->set_sname(tokens[0]);
+			rem_btn->set_scr(tokens[2]);
+			add_custom_control(rem_btn);
+			return true;
+		}
+		if (tokens[3] == "_remove_lang" && tokens[1] == "lang") {
+			ButtonDelLang *rem_btn = memnew(ButtonDelLang);
+			rem_btn->set_text("Remove \"" + tokens[2] + "\" language");
+			rem_btn->set_ff(ff);
+			rem_btn->set_sname(tokens[0]);
+			rem_btn->set_lang(tokens[2]);
+			add_custom_control(rem_btn);
+			return true;
+		}
+	}
+	return false; //do not handle
+}
+
+void EditorInspectorPluginTLFontFamily::parse_end() {
+}

--- a/src/tools/tl_font_family_edit.hpp
+++ b/src/tools/tl_font_family_edit.hpp
@@ -1,0 +1,165 @@
+/*************************************************************************/
+/*  tl_font_family_edit.hpp                                              */
+/*************************************************************************/
+
+#ifndef TL_FONT_FAMILY_EDIT_HPP
+#define TL_FONT_FAMILY_EDIT_HPP
+
+#include "resources/tl_font_family.hpp"
+
+#include "editor/editor_node.h"
+#include "editor/editor_plugin.h"
+
+/*************************************************************************/
+
+class ButtonAddStyle : public Button {
+	GDCLASS(ButtonAddStyle, Button);
+
+	Ref<TLFontFamily> ff;
+	LineEdit *ctl;
+
+protected:
+	virtual void pressed() {
+		if (ff.is_valid() && ctl && ctl->get_text() != String()) {
+			ff->add_style(ctl->get_text());
+		}
+	}
+
+public:
+	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
+	void set_ctl(LineEdit *p_clt) { ctl = p_clt; };
+
+	ButtonAddStyle() {
+		ctl = NULL;
+	}
+};
+
+/*************************************************************************/
+
+class ButtonDelStyle : public Button {
+	GDCLASS(ButtonDelStyle, Button);
+
+	Ref<TLFontFamily> ff;
+	String sname;
+
+protected:
+	virtual void pressed() {
+		if (ff.is_valid()) {
+			ff->remove_style(sname);
+		}
+	}
+
+public:
+	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
+	void set_sname(const String &p_sname) { sname = p_sname; };
+};
+
+/*************************************************************************/
+
+class ButtonAddScript : public Button {
+	GDCLASS(ButtonAddScript, Button);
+
+	Ref<TLFontFamily> ff;
+	String sname;
+	LineEdit *ctl;
+
+protected:
+	virtual void pressed() {
+		if (ff.is_valid() && ctl && ctl->get_text() != String()) {
+			ff->add_script(sname, ctl->get_text());
+		}
+	}
+
+public:
+	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
+	void set_sname(const String &p_sname) { sname = p_sname; };
+	void set_ctl(LineEdit *p_clt) { ctl = p_clt; };
+
+	ButtonAddScript() {
+		ctl = NULL;
+	}
+};
+
+/*************************************************************************/
+
+class ButtonDelScript : public Button {
+	GDCLASS(ButtonDelScript, Button);
+
+	Ref<TLFontFamily> ff;
+	String sname;
+	String scr;
+
+protected:
+	virtual void pressed() {
+		if (ff.is_valid()) {
+			ff->remove_script(sname, scr);
+		}
+	}
+
+public:
+	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
+	void set_sname(const String &p_sname) { sname = p_sname; };
+	void set_scr(const String &p_scr) { scr = p_scr; };
+};
+
+/*************************************************************************/
+
+class ButtonAddLang : public Button {
+	GDCLASS(ButtonAddLang, Button);
+
+	Ref<TLFontFamily> ff;
+	String sname;
+	LineEdit *ctl;
+
+protected:
+	virtual void pressed() {
+		if (ff.is_valid() && ctl && ctl->get_text() != String()) {
+			ff->add_language(sname, ctl->get_text());
+		}
+	}
+
+public:
+	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
+	void set_sname(const String &p_sname) { sname = p_sname; };
+	void set_ctl(LineEdit *p_clt) { ctl = p_clt; };
+
+	ButtonAddLang() {
+		ctl = NULL;
+	}
+};
+
+/*************************************************************************/
+
+class ButtonDelLang : public Button {
+	GDCLASS(ButtonDelLang, Button);
+
+	Ref<TLFontFamily> ff;
+	String sname;
+	String lang;
+
+protected:
+	virtual void pressed() {
+		if (ff.is_valid()) {
+			ff->remove_language(sname, lang);
+		}
+	}
+
+public:
+	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
+	void set_sname(const String &p_sname) { sname = p_sname; };
+	void set_lang(const String &p_lang) { lang = p_lang; };
+};
+
+/*************************************************************************/
+
+class EditorInspectorPluginTLFontFamily : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginTLFontFamily, EditorInspectorPlugin);
+
+public:
+	virtual bool can_handle(Object *p_object);
+	virtual void parse_begin(Object *p_object);
+	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage);
+	virtual void parse_end();
+};
+
+#endif /*TL_FONT_FAMILY_EDIT_HPP*/


### PR DESCRIPTION
Add editor inspector plugin for TLFontFamily (for the module only), to expose all font family config features to the editor UI. (Fixes Nr.4 of #8).

![Screenshot 2019-10-29 at 13 15 50](https://user-images.githubusercontent.com/7645683/67763234-dc7c3a00-fa4f-11e9-8b46-3b4eff03c2dc.png)

Remove all GDNative "Resource" properties. ("Fixes" Nr.1 of #8, should suppress errors and incorrect rendering, but in case of GDNative there's no way to manipulate font data form UI, currently GDNatvie editor plugin and property inspector support is too broken to use it).