### PR TITLE
Port editor inspector plugin and preview to GDScript for use with GDNative module.

### DIFF
--- a/demos/ctrls_gdnative/Control.tscn
+++ b/demos/ctrls_gdnative/Control.tscn
@@ -1,44 +1,41 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://addons/libgdtl/classes/tl_label.gdns" type="Script" id=1]
 [ext_resource path="res://fonts/NotoSans-Bold.ttf" type="DynamicFontData" id=2]
 [ext_resource path="res://addons/libgdtl/classes/tl_line_edit.gdns" type="Script" id=3]
 [ext_resource path="res://fonts/NotoNastaliqUrdu-Regular.ttf" type="DynamicFontData" id=4]
+[ext_resource path="res://addons/libgdtl/classes/tl_font_family.gdns" type="Script" id=5]
+[ext_resource path="res://addons/libgdtl/classes/tl_dynamic_font_face.gdns" type="Script" id=6]
 
-[sub_resource type="GDScript" id=1]
-script/source = "extends Control
+[sub_resource type="Resource" id=2]
+script = ExtResource( 6 )
+font_path = "res://fonts/NotoSans-Bold.ttf"
+texture_flags = 2048
+force_autohinter = false
+hinting = 2
+oversampling = 1.0
 
-const TLFontFamily = preload(\"res://addons/libgdtl/classes/tl_font_family.gdns\")
-const TLDynamicFontFace = preload(\"res://addons/libgdtl/classes/tl_dynamic_font_face.gdns\")
+[sub_resource type="Resource" id=3]
+script = ExtResource( 5 )
+regular/0 = SubResource( 2 )
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	var face1 = TLDynamicFontFace.new()
-	face1.load(\"res://fonts/NotoSans-Bold.ttf\")
-	
-	var font1 = TLFontFamily.new()
-	font1.add_face(\"Default\", face1)
-	
-	$TLLabel.set_base_font(font1)
-	$TLLabel.set_base_font_style(\"Default\")
-	$TLLabel.set_base_font_size(12)
-	
-	var face2 = TLDynamicFontFace.new()
-	face2.load(\"res://fonts/NotoNastaliqUrdu-Regular.ttf\")
-	
-	var font2 = TLFontFamily.new()
-	font2.add_face(\"Default\", face2)
-	
-	$TLLineEdit.set_base_font(font2)
-	$TLLineEdit.set_base_font_style(\"Default\")
-	$TLLineEdit.set_base_font_size(12)
-"
-
-[sub_resource type="DynamicFont" id=2]
+[sub_resource type="DynamicFont" id=4]
 size = 12
 font_data = ExtResource( 2 )
 
-[sub_resource type="DynamicFont" id=3]
+[sub_resource type="Resource" id=6]
+script = ExtResource( 6 )
+font_path = "res://fonts/NotoNastaliqUrdu-Regular.ttf"
+texture_flags = 2048
+force_autohinter = false
+hinting = 2
+oversampling = 1.0
+
+[sub_resource type="Resource" id=7]
+script = ExtResource( 5 )
+regular/0 = SubResource( 6 )
+
+[sub_resource type="DynamicFont" id=5]
 size = 12
 font_data = ExtResource( 4 )
 
@@ -49,7 +46,6 @@ margin_left = 1.0
 margin_top = -1.0
 margin_right = 1.0
 margin_bottom = -1.0
-script = SubResource( 1 )
 
 [node name="TLLabel" type="Control" parent="."]
 margin_left = 111.0
@@ -60,8 +56,12 @@ rect_min_size = Vector2( 209, 110 )
 mouse_filter = 2
 size_flags_vertical = 4
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 text = "test232
 Godot Label"
+base_font = SubResource( 3 )
 
 [node name="Label" type="Label" parent="."]
 margin_left = 401.0
@@ -69,20 +69,21 @@ margin_top = 37.0
 margin_right = 611.0
 margin_bottom = 151.0
 rect_min_size = Vector2( 210, 114 )
-custom_fonts/font = SubResource( 2 )
+custom_fonts/font = SubResource( 4 )
 text = "test232
 Godot Label"
 
 [node name="TLLineEdit" type="Control" parent="."]
-margin_left = 100.0
+margin_left = 99.0
 margin_top = 159.0
-margin_right = 322.0
+margin_right = 321.0
 margin_bottom = 200.0
 rect_min_size = Vector2( 222, 41 )
 focus_mode = 2
 mouse_default_cursor_shape = 1
 script = ExtResource( 3 )
 text = "اور بازار سے لے آئے اگر ٹوٹ گیا"
+base_font = SubResource( 7 )
 secret_character = "*"
 
 [node name="LineEdit" type="LineEdit" parent="."]
@@ -91,5 +92,5 @@ margin_top = 159.0
 margin_right = 612.0
 margin_bottom = 200.0
 rect_min_size = Vector2( 222, 41 )
-custom_fonts/font = SubResource( 3 )
+custom_fonts/font = SubResource( 5 )
 text = "اور بازار سے لے آئے اگر ٹوٹ گیا"

--- a/libgdtl/gdtl.gd
+++ b/libgdtl/gdtl.gd
@@ -1,11 +1,15 @@
 tool
 extends EditorPlugin
 
+const EditorInspectorPluginTLFontFamily = preload("res://addons/libgdtl/tl_font_family_edit.gd")
+var inspector_plug
+
 func _enter_tree():
+    inspector_plug = EditorInspectorPluginTLFontFamily.new()
     add_custom_type("TLICUDataLoader", "Resource", preload("res://addons/libgdtl/classes/tl_icu_data_loader.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_i_c_u_data_loader.svg"))
     add_custom_type("TLFontFace", "Resource", preload("res://addons/libgdtl/classes/tl_font_face.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_font_face.svg"))
-    add_custom_type("TLBitmapFontFace", "TLFontFace", preload("res://addons/libgdtl/classes/tl_bitmap_font_face.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_bitmap_font_face.svg"))
-    add_custom_type("TLDynamicFontFace", "TLFontFace", preload("res://addons/libgdtl/classes/tl_dynamic_font_face.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_dynamic_font_face.svg"))
+    add_custom_type("TLBitmapFontFace", "Resource", preload("res://addons/libgdtl/classes/tl_bitmap_font_face.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_bitmap_font_face.svg"))
+    add_custom_type("TLDynamicFontFace", "Resource", preload("res://addons/libgdtl/classes/tl_dynamic_font_face.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_dynamic_font_face.svg"))
     add_custom_type("TLFontFamily", "Resource", preload("res://addons/libgdtl/classes/tl_font_family.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_font_family.svg"))
     add_custom_type("TLShapedString", "Resource", preload("res://addons/libgdtl/classes/tl_shaped_string.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_shaped_string.svg"))
     add_custom_type("TLShapedAttributedString", "TLShapedString", preload("res://addons/libgdtl/classes/tl_shaped_attributed_string.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_shaped_attributed_string.svg"))
@@ -15,6 +19,7 @@ func _enter_tree():
     add_custom_type("TLLabel", "Control", preload("res://addons/libgdtl/classes/tl_label.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_label.svg"))
     add_custom_type("TLLineEdit", "Control", preload("res://addons/libgdtl/classes/tl_line_edit.gdns"), preload("res://addons/libgdtl/icons/icon_t_l_line_edit.svg"))
     add_autoload_singleton("TLConstants", "res://addons/libgdtl/constants.gd")
+    add_inspector_plugin(inspector_plug)
 
 func _exit_tree():
     remove_custom_type("TLICUDataLoader")
@@ -29,3 +34,4 @@ func _exit_tree():
     remove_custom_type("TLProtoControlSelection")
     remove_custom_type("TLLabel")
     remove_custom_type("TLLineEdit")
+    remove_inspector_plugin(inspector_plug)

--- a/libgdtl/tl_font_family_edit.gd
+++ b/libgdtl/tl_font_family_edit.gd
@@ -1,0 +1,113 @@
+tool
+extends EditorInspectorPlugin
+
+const TLFontFamily = preload("res://addons/libgdtl/classes/tl_font_family.gdns")
+const TLFontFamilyPreview = preload("res://addons/libgdtl/tl_font_family_preview.gd")
+
+func can_handle(object):
+	var scr = object.get_script()
+	if (scr && scr.is_class("NativeScript") && scr.get_class_name() == "TLFontFamily"):
+		return true
+
+func parse_begin(object):
+	pass
+
+func parse_category(object, category):
+	pass
+
+func parse_end():
+	pass
+
+func _new_style(p_object, p_ctl):
+	if (p_object && p_ctl && p_ctl.get_text() != ""):
+		p_object.add_style(p_ctl.get_text())
+
+func _remove_style(p_object, p_style):
+	if (p_object):
+		p_object.remove_style(p_style)
+
+func _new_lang(p_object, p_style, p_ctl):
+	if (p_object && p_ctl && p_ctl.get_text() != ""):
+		p_object.add_language(p_style, p_ctl.get_text())
+
+func _new_script(p_object, p_style, p_ctl):
+	if (p_object && p_ctl && p_ctl.get_text() != ""):
+		p_object.add_script(p_style, p_ctl.get_text())
+
+func _remove_lang(p_object, p_style, p_lang):
+	if (p_object):
+		p_object.remove_language(p_style, p_lang)
+
+func _remove_script(p_object, p_style, p_script):
+	if (p_object):
+		p_object.remove_script(p_style, p_script)
+
+func parse_property(p_object, p_type, p_path, p_hint, p_hint_text, p_usage):
+	if (p_path == "_new_style"):
+		var hbox = HBoxContainer.new()
+		var new_name = LineEdit.new()
+		new_name.set_h_size_flags(Control.SIZE_EXPAND_FILL)
+		new_name.set_placeholder("Style name")
+		hbox.add_child(new_name)
+		var new_btn = Button.new()
+		new_btn.set_h_size_flags(Control.SIZE_EXPAND_FILL);
+		new_btn.connect("pressed", self, "_new_style", [p_object, new_name])
+		new_btn.set_text("Add style");
+		hbox.add_child(new_btn);
+		add_custom_control(hbox);
+		return true;
+	var tokens = p_path.split("/");
+	if (tokens.size() == 2):
+		if (tokens[1] == "_prev_style"):
+			var prev = TLFontFamilyPreview.new()
+			prev.set_ff(p_object, tokens[0])
+			add_custom_control(prev)
+			return true;
+		elif (tokens[1] == "_remove_style"):
+			var rem_btn = Button.new()
+			rem_btn.set_text("Remove \"" + tokens[0] + "\" style");
+			rem_btn.connect("pressed", self, "_remove_style", [p_object, tokens[0]])
+			add_custom_control(rem_btn)
+			return true;
+		elif (tokens[1] == "_add_lang"):
+			var hbox = HBoxContainer.new()
+			var new_name = LineEdit.new()
+			new_name.set_h_size_flags(Control.SIZE_EXPAND_FILL);
+			new_name.set_max_length(4)
+			new_name.set_placeholder("ISO language code");
+			hbox.add_child(new_name)
+			var new_btn = Button.new()
+			new_btn.set_h_size_flags(Control.SIZE_EXPAND_FILL);
+			new_btn.connect("pressed", self, "_new_lang", [p_object, tokens[0], new_name])
+			new_btn.set_text("Add language")
+			hbox.add_child(new_btn)
+			add_custom_control(hbox)
+			return true;
+		elif (tokens[1] == "_add_script"):
+			var hbox = HBoxContainer.new()
+			var new_name = LineEdit.new()
+			new_name.set_h_size_flags(Control.SIZE_EXPAND_FILL);
+			new_name.set_max_length(4)
+			new_name.set_placeholder("ISO script code")
+			hbox.add_child(new_name)
+			var new_btn = Button.new()
+			new_btn.set_h_size_flags(Control.SIZE_EXPAND_FILL);
+			new_btn.connect("pressed", self, "_new_script", [p_object, tokens[0], new_name])
+			new_btn.set_text("Add script")
+			hbox.add_child(new_btn)
+			add_custom_control(hbox)
+			return true;
+	elif (tokens.size() == 4):
+		if (tokens[3] == "_remove_script" && tokens[1] == "script"):
+			var rem_btn = Button.new()
+			rem_btn.set_text("Remove \"" + tokens[2] + "\" script");
+			rem_btn.connect("pressed", self, "_remove_script", [p_object, tokens[0], tokens[2]])
+			add_custom_control(rem_btn)
+			return true;
+		elif (tokens[3] == "_remove_lang" && tokens[1] == "lang"):
+			var rem_btn = Button.new()
+			rem_btn.set_text("Remove \"" + tokens[2] + "\" language");
+			rem_btn.connect("pressed", self, "_remove_lang", [p_object, tokens[0], tokens[2]])
+			add_custom_control(rem_btn)
+			return true
+	return false

--- a/libgdtl/tl_font_family_preview.gd
+++ b/libgdtl/tl_font_family_preview.gd
@@ -1,0 +1,33 @@
+tool
+extends VBoxContainer
+
+const TLShapedString = preload("res://addons/libgdtl/classes/tl_shaped_string.gdns")
+
+var preview
+var strctx
+var ctl
+
+func _ff_changed(p_text):
+	strctx.set_text(p_text)
+	preview.update()
+
+func _redraw():
+	VisualServer.canvas_item_add_rect(preview.get_canvas_item(), Rect2(Vector2(), preview.get_size()), Color(0.8, 0.8, 0.8, 1))
+	strctx.draw(preview.get_canvas_item(), Vector2((preview.get_rect().size.x - strctx.get_width()) / 2, (preview.get_rect().size.y - strctx.get_height()) / 2 + strctx.get_ascent()), Color(0, 0, 0, 1))
+
+func set_ff(p_ff, p_style):
+	strctx.set_base_font(p_ff);
+	strctx.set_base_font_style(p_style);
+
+func _init():
+	strctx = TLShapedString.new()
+	strctx.set_base_font_size(18.0)
+	strctx.set_text("Etaoin shrdlu")
+	preview = Control.new();
+	preview.set_custom_minimum_size(Vector2(0, 50))
+	preview.connect("draw", self, "_redraw")
+	add_child(preview)
+	ctl = LineEdit.new()
+	ctl.set_text("Etaoin shrdlu")
+	ctl.connect("text_changed", self, "_ff_changed")
+	add_child(ctl)

--- a/src/controls/tl_label.cpp
+++ b/src/controls/tl_label.cpp
@@ -513,6 +513,8 @@ void TLLabel::set_visible_characters(int p_amount) {
 	}
 #ifdef GODOT_MODULE
 	_change_notify("percent_visible");
+#else
+	property_list_changed_notify();
 #endif
 	update();
 }
@@ -536,6 +538,8 @@ void TLLabel::set_percent_visible(float p_percent) {
 	}
 #ifdef GODOT_MODULE
 	_change_notify("visible_chars");
+#else
+	property_list_changed_notify();
 #endif
 	update();
 }
@@ -698,7 +702,7 @@ void TLLabel::_register_methods() {
 	register_property<TLLabel, int>("align", &TLLabel::set_align, &TLLabel::get_align, ALIGN_LEFT, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, String("Left,Center,Right,Fill"));
 	register_property<TLLabel, int>("valign", &TLLabel::set_valign, &TLLabel::get_valign, VALIGN_TOP, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, String("Top,Center,Bottom,Fill"));
 
-	register_property<TLLabel, Ref<TLFontFamily> >("base_font", &TLLabel::set_base_font, &TLLabel::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_NOEDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
+	register_property<TLLabel, Ref<TLFontFamily> >("base_font", &TLLabel::set_base_font, &TLLabel::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_EDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
 	register_property<TLLabel, String>("base_font_style", &TLLabel::set_base_font_style, &TLLabel::get_base_font_style, String("Regular"));
 	register_property<TLLabel, int>("base_font_size", &TLLabel::set_base_font_size, &TLLabel::get_base_font_size, 12);
 

--- a/src/controls/tl_line_edit.cpp
+++ b/src/controls/tl_line_edit.cpp
@@ -1629,6 +1629,8 @@ void TLLineEdit::_emit_text_change() {
 	emit_signal("text_changed", text);
 #ifdef GODOT_MODULE
 	_change_notify("text");
+#else
+	property_list_changed_notify();
 #endif
 	text_changed_dirty = false;
 }
@@ -1839,7 +1841,7 @@ void TLLineEdit::_register_methods() {
 	register_property<TLLineEdit, String>("text", &TLLineEdit::set_text, &TLLineEdit::get_text, String(), GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_MULTILINE_TEXT, String(""));
 	register_property<TLLineEdit, int>("align", &TLLineEdit::set_align, &TLLineEdit::get_align, ALIGN_LEFT, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, String("Left,Center,Right,Fill"));
 
-	register_property<TLLineEdit, Ref<TLFontFamily> >("base_font", &TLLineEdit::set_base_font, &TLLineEdit::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_NOEDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
+	register_property<TLLineEdit, Ref<TLFontFamily> >("base_font", &TLLineEdit::set_base_font, &TLLineEdit::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_EDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
 	register_property<TLLineEdit, String>("base_font_style", &TLLineEdit::set_base_font_style, &TLLineEdit::get_base_font_style, String("Regular"));
 	register_property<TLLineEdit, int>("base_font_size", &TLLineEdit::set_base_font_size, &TLLineEdit::get_base_font_size, 12);
 

--- a/src/controls/tl_proto_control.cpp
+++ b/src/controls/tl_proto_control.cpp
@@ -354,6 +354,8 @@ int TLProtoControl::insert_paragraph(Ref<TLShapedParagraph> p_para, int p_index)
 	_update_ctx_rect();
 #ifdef GODOT_MODULE
 	_change_notify();
+#else
+	property_list_changed_notify();
 #endif
 
 	return std::distance(paragraphs.begin(), paragraphs.insert(paragraphs.begin() + p_index, new_para));
@@ -370,6 +372,8 @@ void TLProtoControl::remove_paragraph(int p_index) {
 	_update_ctx_rect();
 #ifdef GODOT_MODULE
 	_change_notify();
+#else
+	property_list_changed_notify();
 #endif
 
 	emit_signal("cursor_changed");

--- a/src/resources/tl_font_family.cpp
+++ b/src/resources/tl_font_family.cpp
@@ -242,8 +242,11 @@ TLFontFamily::~TLFontFamily() {
 void TLFontFamily::add_style(String p_style) {
 	if (styles.count(p_style.to_upper()) == 0) {
 		styles[p_style.to_upper()] = StyleData();
+		emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 		_change_notify();
+#else
+		property_list_changed_notify();
 #endif
 	}
 }
@@ -253,8 +256,11 @@ void TLFontFamily::add_script(String p_style, String p_script) {
 		hb_script_t scr = hb_script_from_string(p_script.ascii().get_data(), -1);
 		if (styles[p_style.to_upper()].linked_src_chain.count(scr) == 0) {
 			styles[p_style.to_upper()].linked_src_chain[scr] = std::vector<Ref<TLFontFace> >();
+			emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 			_change_notify();
+#else
+			property_list_changed_notify();
 #endif
 		}
 	}
@@ -265,8 +271,11 @@ void TLFontFamily::add_language(String p_style, String p_lang) {
 		hb_language_t lang = hb_language_from_string(p_lang.ascii().get_data(), -1);
 		if (styles[p_style.to_upper()].linked_lang_chain.count(lang) == 0) {
 			styles[p_style.to_upper()].linked_lang_chain[lang] = std::vector<Ref<TLFontFace> >();
+			emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 			_change_notify();
+#else
+			property_list_changed_notify();
 #endif
 		}
 	}
@@ -280,8 +289,11 @@ void TLFontFamily::remove_script(String p_style, String p_script) {
 				_dec_ref(*E);
 			}
 			styles[p_style.to_upper()].linked_src_chain.erase(scr);
+			emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 			_change_notify();
+#else
+			property_list_changed_notify();
 #endif
 		}
 	}
@@ -295,8 +307,11 @@ void TLFontFamily::remove_language(String p_style, String p_lang) {
 				_dec_ref(*E);
 			}
 			styles[p_style.to_upper()].linked_lang_chain.erase(lang);
+			emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 			_change_notify();
+#else
+			property_list_changed_notify();
 #endif
 		}
 	}
@@ -319,8 +334,11 @@ void TLFontFamily::remove_style(String p_style) {
 	}
 
 	styles.erase(p_style.to_upper());
+	emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 	_change_notify();
+#else
+	property_list_changed_notify();
 #endif
 }
 
@@ -381,9 +399,11 @@ void TLFontFamily::add_face(String p_style, Ref<TLFontFace> p_ref) {
 			styles[p_style.to_upper()].main_chain.push_back(p_ref);
 		}
 	}
-
+	emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 	_change_notify();
+#else
+	property_list_changed_notify();
 #endif
 }
 
@@ -397,9 +417,11 @@ void TLFontFamily::add_face_unlinked(String p_style, Ref<TLFontFace> p_ref) {
 	_inc_ref(p_ref);
 
 	styles[p_style.to_upper()].main_chain.push_back(p_ref);
-
+	emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 	_change_notify();
+#else
+	property_list_changed_notify();
 #endif
 }
 
@@ -414,9 +436,11 @@ void TLFontFamily::add_face_for_script(String p_style, Ref<TLFontFace> p_ref, St
 
 	hb_script_t scr = hb_script_from_string(p_script.ascii().get_data(), -1);
 	styles[p_style.to_upper()].linked_src_chain[scr].push_back(p_ref);
-
+	emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 	_change_notify();
+#else
+	property_list_changed_notify();
 #endif
 }
 
@@ -431,9 +455,11 @@ void TLFontFamily::add_face_for_language(String p_style, Ref<TLFontFace> p_ref, 
 
 	hb_language_t lang = hb_language_from_string(p_lang.ascii().get_data(), -1);
 	styles[p_style.to_upper()].linked_lang_chain[lang].push_back(p_ref);
-
+	emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 	_change_notify();
+#else
+	property_list_changed_notify();
 #endif
 }
 
@@ -479,6 +505,8 @@ void TLFontFamily::_font_changed() {
 	emit_signal(_CHANGED);
 #ifdef GODOT_MODULE
 	_change_notify();
+#else
+	property_list_changed_notify();
 #endif
 }
 
@@ -519,6 +547,7 @@ bool TLFontFamily::_set(const StringName &p_name, const Variant &p_value) {
 				if (face.is_valid()) {
 					_inc_ref(face);
 					styles[style.to_upper()].main_chain.push_back(face);
+					emit_signal(_CHANGED);
 					_change_notify();
 					return true;
 				}
@@ -527,12 +556,14 @@ bool TLFontFamily::_set(const StringName &p_name, const Variant &p_value) {
 				if (face.is_null()) {
 					_dec_ref(styles[style.to_upper()].main_chain[index]);
 					styles[style.to_upper()].main_chain.erase(styles[style.to_upper()].main_chain.begin() + index);
+					emit_signal(_CHANGED);
 					_change_notify();
 					return true;
 				} else {
 					_dec_ref(styles[style.to_upper()].main_chain[index]);
 					_inc_ref(face);
 					styles[style.to_upper()].main_chain[index] = face;
+					emit_signal(_CHANGED);
 					_change_notify();
 					return true;
 				}
@@ -547,6 +578,7 @@ bool TLFontFamily::_set(const StringName &p_name, const Variant &p_value) {
 					if (face.is_valid()) {
 						_inc_ref(face);
 						styles[style.to_upper()].linked_src_chain[scr].push_back(face);
+						emit_signal(_CHANGED);
 						_change_notify();
 						return true;
 					}
@@ -555,12 +587,14 @@ bool TLFontFamily::_set(const StringName &p_name, const Variant &p_value) {
 					if (face.is_null()) {
 						_dec_ref(styles[style.to_upper()].linked_src_chain[scr][index]);
 						styles[style.to_upper()].linked_src_chain[scr].erase(styles[style.to_upper()].linked_src_chain[scr].begin() + index);
+						emit_signal(_CHANGED);
 						_change_notify();
 						return true;
 					} else {
 						_dec_ref(styles[style.to_upper()].linked_src_chain[scr][index]);
 						_inc_ref(face);
 						styles[style.to_upper()].linked_src_chain[scr][index] = face;
+						emit_signal(_CHANGED);
 						_change_notify();
 						return true;
 					}
@@ -573,6 +607,7 @@ bool TLFontFamily::_set(const StringName &p_name, const Variant &p_value) {
 					if (face.is_valid()) {
 						_inc_ref(face);
 						styles[style.to_upper()].linked_lang_chain[lang].push_back(face);
+						emit_signal(_CHANGED);
 						_change_notify();
 						return true;
 					}
@@ -581,12 +616,14 @@ bool TLFontFamily::_set(const StringName &p_name, const Variant &p_value) {
 					if (face.is_null()) {
 						_dec_ref(styles[style.to_upper()].linked_lang_chain[lang][index]);
 						styles[style.to_upper()].linked_lang_chain[lang].erase(styles[style.to_upper()].linked_lang_chain[lang].begin() + index);
+						emit_signal(_CHANGED);
 						_change_notify();
 						return true;
 					} else {
 						_dec_ref(styles[style.to_upper()].linked_lang_chain[lang][index]);
 						_inc_ref(face);
 						styles[style.to_upper()].linked_lang_chain[lang][index] = face;
+						emit_signal(_CHANGED);
 						_change_notify();
 						return true;
 					}
@@ -710,6 +747,8 @@ bool TLFontFamily::_set(String p_name, Variant p_value) {
 				if (face.is_valid()) {
 					_inc_ref(face);
 					styles[style.to_upper()].main_chain.push_back(face);
+					emit_signal(_CHANGED);
+					property_list_changed_notify();
 					return true;
 				}
 			} else if ((index >= 0) && (index < (int64_t)styles[style.to_upper()].main_chain.size())) {
@@ -717,11 +756,15 @@ bool TLFontFamily::_set(String p_name, Variant p_value) {
 				if (face.is_null()) {
 					_dec_ref(styles[style.to_upper()].main_chain[index]);
 					styles[style.to_upper()].main_chain.erase(styles[style.to_upper()].main_chain.begin() + index);
+					emit_signal(_CHANGED);
+					property_list_changed_notify();
 					return true;
 				} else {
 					_dec_ref(styles[style.to_upper()].main_chain[index]);
 					_inc_ref(face);
 					styles[style.to_upper()].main_chain[index] = face;
+					emit_signal(_CHANGED);
+					property_list_changed_notify();
 					return true;
 				}
 			}
@@ -735,6 +778,8 @@ bool TLFontFamily::_set(String p_name, Variant p_value) {
 					if (face.is_valid()) {
 						_inc_ref(face);
 						styles[style.to_upper()].linked_src_chain[scr].push_back(face);
+						emit_signal(_CHANGED);
+						property_list_changed_notify();
 						return true;
 					}
 				} else if ((index >= 0) && (index < (int64_t)styles[style.to_upper()].linked_src_chain[scr].size())) {
@@ -742,11 +787,15 @@ bool TLFontFamily::_set(String p_name, Variant p_value) {
 					if (face.is_null()) {
 						_dec_ref(styles[style.to_upper()].linked_src_chain[scr][index]);
 						styles[style.to_upper()].linked_src_chain[scr].erase(styles[style.to_upper()].linked_src_chain[scr].begin() + index);
+						emit_signal(_CHANGED);
+						property_list_changed_notify();
 						return true;
 					} else {
 						_dec_ref(styles[style.to_upper()].linked_src_chain[scr][index]);
 						_inc_ref(face);
 						styles[style.to_upper()].linked_src_chain[scr][index] = face;
+						emit_signal(_CHANGED);
+						property_list_changed_notify();
 						return true;
 					}
 				}
@@ -758,6 +807,8 @@ bool TLFontFamily::_set(String p_name, Variant p_value) {
 					if (face.is_valid()) {
 						_inc_ref(face);
 						styles[style.to_upper()].linked_lang_chain[lang].push_back(face);
+						emit_signal(_CHANGED);
+						property_list_changed_notify();
 						return true;
 					}
 				} else if ((index >= 0) && (index < (int64_t)styles[style.to_upper()].linked_lang_chain[lang].size())) {
@@ -765,11 +816,15 @@ bool TLFontFamily::_set(String p_name, Variant p_value) {
 					if (face.is_null()) {
 						_dec_ref(styles[style.to_upper()].linked_lang_chain[lang][index]);
 						styles[style.to_upper()].linked_lang_chain[lang].erase(styles[style.to_upper()].linked_lang_chain[lang].begin() + index);
+						emit_signal(_CHANGED);
+						property_list_changed_notify();
 						return true;
 					} else {
 						_dec_ref(styles[style.to_upper()].linked_lang_chain[lang][index]);
 						_inc_ref(face);
 						styles[style.to_upper()].linked_lang_chain[lang][index] = face;
+						emit_signal(_CHANGED);
+						property_list_changed_notify();
 						return true;
 					}
 				}
@@ -824,15 +879,15 @@ Array TLFontFamily::_get_property_list() const {
 	Array ret;
 	for (auto it = styles.begin(); it != styles.end(); ++it) {
 
-		// {
-		// 	Dictionary prop;
-		// 	prop["name"] = it->first.to_lower() + "/" + "_prev_style";
-		// 	prop["type"] = GlobalConstants::TYPE_NIL;
-		// 	prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
-		// 	prop["hint_string"] = "";
-		// 	prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
-		// 	ret.push_back(prop);
-		// }
+		{
+			Dictionary prop;
+			prop["name"] = it->first.to_lower() + "/" + "_prev_style";
+			prop["type"] = GlobalConstants::TYPE_NIL;
+			prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
+			prop["hint_string"] = "";
+			prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
+			ret.push_back(prop);
+		}
 
 		for (int i = 0; i < it->second.main_chain.size(); i++) {
 			Dictionary prop;
@@ -840,18 +895,18 @@ Array TLFontFamily::_get_property_list() const {
 			prop["type"] = GlobalConstants::TYPE_OBJECT;
 			prop["hint"] = GlobalConstants::PROPERTY_HINT_RESOURCE_TYPE;
 			prop["hint_string"] = "TLFontFace";
-			prop["usage"] = GlobalConstants::PROPERTY_USAGE_NOEDITOR | GlobalConstants::PROPERTY_USAGE_STORAGE;
+			prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR | GlobalConstants::PROPERTY_USAGE_STORAGE;
 			ret.push_back(prop);
 		}
-		// {
-		// 	Dictionary prop;
-		// 	prop["name"] = it->first.to_lower() + "/" + String::num_int64(it->second.main_chain.size());
-		// 	prop["type"] = GlobalConstants::TYPE_OBJECT;
-		// 	prop["hint"] = GlobalConstants::PROPERTY_HINT_RESOURCE_TYPE;
-		// 	prop["hint_string"] = "TLFontFace";
-		// 	prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
-		// 	ret.push_back(prop);
-		// }
+		{
+			Dictionary prop;
+			prop["name"] = it->first.to_lower() + "/" + String::num_int64(it->second.main_chain.size());
+			prop["type"] = GlobalConstants::TYPE_OBJECT;
+			prop["hint"] = GlobalConstants::PROPERTY_HINT_RESOURCE_TYPE;
+			prop["hint_string"] = "TLFontFace";
+			prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
+			ret.push_back(prop);
+		}
 
 		for (auto sit = it->second.linked_src_chain.begin(); sit != it->second.linked_src_chain.end(); ++sit) {
 			char tag[5] = "";
@@ -862,37 +917,37 @@ Array TLFontFamily::_get_property_list() const {
 				prop["type"] = GlobalConstants::TYPE_OBJECT;
 				prop["hint"] = GlobalConstants::PROPERTY_HINT_RESOURCE_TYPE;
 				prop["hint_string"] = "TLFontFace";
-				prop["usage"] = GlobalConstants::PROPERTY_USAGE_NOEDITOR | GlobalConstants::PROPERTY_USAGE_STORAGE;
+				prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR | GlobalConstants::PROPERTY_USAGE_STORAGE;
 				ret.push_back(prop);
 			}
-			// {
-			// 	Dictionary prop;
-			// 	prop["name"] = it->first.to_lower() + "/script/" + tag + "/" + String::num_int64(sit->second.size());
-			// 	prop["type"] = GlobalConstants::TYPE_OBJECT;
-			// 	prop["hint"] = GlobalConstants::PROPERTY_HINT_RESOURCE_TYPE;
-			// 	prop["hint_string"] = "TLFontFace";
-			// 	prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR | GlobalConstants::PROPERTY_USAGE_STORAGE;
-			// 	ret.push_back(prop);
-			// }
-			// {
-			// 	Dictionary prop;
-			// 	prop["name"] = it->first.to_lower() + "/script/" + tag + "/" + "_remove_script";
-			// 	prop["type"] = GlobalConstants::TYPE_NIL;
-			// 	prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
-			// 	prop["hint_string"] = "";
-			// 	prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
-			// 	ret.push_back(prop);
-			// }
+			{
+				Dictionary prop;
+				prop["name"] = it->first.to_lower() + "/script/" + tag + "/" + String::num_int64(sit->second.size());
+				prop["type"] = GlobalConstants::TYPE_OBJECT;
+				prop["hint"] = GlobalConstants::PROPERTY_HINT_RESOURCE_TYPE;
+				prop["hint_string"] = "TLFontFace";
+				prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR | GlobalConstants::PROPERTY_USAGE_STORAGE;
+				ret.push_back(prop);
+			}
+			{
+				Dictionary prop;
+				prop["name"] = it->first.to_lower() + "/script/" + tag + "/" + "_remove_script";
+				prop["type"] = GlobalConstants::TYPE_NIL;
+				prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
+				prop["hint_string"] = "";
+				prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
+				ret.push_back(prop);
+			}
 		}
-		// {
-		// 	Dictionary prop;
-		// 	prop["name"] = it->first.to_lower() + "/" + "_add_script";
-		// 	prop["type"] = GlobalConstants::TYPE_NIL;
-		// 	prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
-		// 	prop["hint_string"] = "";
-		// 	prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
-		// 	ret.push_back(prop);
-		// }
+		{
+			Dictionary prop;
+			prop["name"] = it->first.to_lower() + "/" + "_add_script";
+			prop["type"] = GlobalConstants::TYPE_NIL;
+			prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
+			prop["hint_string"] = "";
+			prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
+			ret.push_back(prop);
+		}
 		for (auto sit = it->second.linked_lang_chain.begin(); sit != it->second.linked_lang_chain.end(); ++sit) {
 
 			for (int i = 0; i < sit->second.size(); i++) {
@@ -901,56 +956,56 @@ Array TLFontFamily::_get_property_list() const {
 				prop["type"] = GlobalConstants::TYPE_OBJECT;
 				prop["hint"] = GlobalConstants::PROPERTY_HINT_RESOURCE_TYPE;
 				prop["hint_string"] = "TLFontFace";
-				prop["usage"] = GlobalConstants::PROPERTY_USAGE_NOEDITOR | GlobalConstants::PROPERTY_USAGE_STORAGE;
+				prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR | GlobalConstants::PROPERTY_USAGE_STORAGE;
 				ret.push_back(prop);
 			}
-			// {
-			// 	Dictionary prop;
-			// 	prop["name"] = it->first.to_lower() + "/lang/" + hb_language_to_string(sit->first) + "/" + String::num_int64(sit->second.size());
-			// 	prop["type"] = GlobalConstants::TYPE_OBJECT;
-			// 	prop["hint"] = GlobalConstants::PROPERTY_HINT_RESOURCE_TYPE;
-			// 	prop["hint_string"] = "TLFontFace";
-			// 	prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR | GlobalConstants::PROPERTY_USAGE_STORAGE;
-			// 	ret.push_back(prop);
-			// }
-			// {
-			// 	Dictionary prop;
-			// 	prop["name"] = it->first.to_lower() + "/lang/" + hb_language_to_string(sit->first) + "/" + "_remove_script";
-			// 	prop["type"] = GlobalConstants::TYPE_NIL;
-			// 	prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
-			// 	prop["hint_string"] = "";
-			// 	prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
-			// 	ret.push_back(prop);
-			// }
+			{
+				Dictionary prop;
+				prop["name"] = it->first.to_lower() + "/lang/" + hb_language_to_string(sit->first) + "/" + String::num_int64(sit->second.size());
+				prop["type"] = GlobalConstants::TYPE_OBJECT;
+				prop["hint"] = GlobalConstants::PROPERTY_HINT_RESOURCE_TYPE;
+				prop["hint_string"] = "TLFontFace";
+				prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR | GlobalConstants::PROPERTY_USAGE_STORAGE;
+				ret.push_back(prop);
+			}
+			{
+				Dictionary prop;
+				prop["name"] = it->first.to_lower() + "/lang/" + hb_language_to_string(sit->first) + "/" + "_remove_script";
+				prop["type"] = GlobalConstants::TYPE_NIL;
+				prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
+				prop["hint_string"] = "";
+				prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
+				ret.push_back(prop);
+			}
 		}
-		// {
-		// 	Dictionary prop;
-		// 	prop["name"] = it->first.to_lower() + "/" + "_add_lang";
-		// 	prop["type"] = GlobalConstants::TYPE_NIL;
-		// 	prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
-		// 	prop["hint_string"] = "";
-		// 	prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
-		// 	ret.push_back(prop);
-		// }
-		// {
-		// 	Dictionary prop;
-		// 	prop["name"] = it->first.to_lower() + "/" + "_remove_style";
-		// 	prop["type"] = GlobalConstants::TYPE_NIL;
-		// 	prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
-		// 	prop["hint_string"] = "";
-		// 	prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
-		// 	ret.push_back(prop);
-		// }
+		{
+			Dictionary prop;
+			prop["name"] = it->first.to_lower() + "/" + "_add_lang";
+			prop["type"] = GlobalConstants::TYPE_NIL;
+			prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
+			prop["hint_string"] = "";
+			prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
+			ret.push_back(prop);
+		}
+		{
+			Dictionary prop;
+			prop["name"] = it->first.to_lower() + "/" + "_remove_style";
+			prop["type"] = GlobalConstants::TYPE_NIL;
+			prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
+			prop["hint_string"] = "";
+			prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
+			ret.push_back(prop);
+		}
 	}
-	// {
-	// 	Dictionary prop;
-	// 	prop["name"] = "_new_style";
-	// 	prop["type"] = GlobalConstants::TYPE_NIL;
-	// 	prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
-	// 	prop["hint_string"] = "";
-	// 	prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
-	// 	ret.push_back(prop);
-	// }
+	{
+		Dictionary prop;
+		prop["name"] = "_new_style";
+		prop["type"] = GlobalConstants::TYPE_NIL;
+		prop["hint"] = GlobalConstants::PROPERTY_HINT_NONE;
+		prop["hint_string"] = "";
+		prop["usage"] = GlobalConstants::PROPERTY_USAGE_EDITOR;
+		ret.push_back(prop);
+	}
 	return ret;
 }
 

--- a/src/resources/tl_shaped_paragraph.cpp
+++ b/src/resources/tl_shaped_paragraph.cpp
@@ -347,7 +347,7 @@ void TLShapedParagraph::_register_methods() {
 
 	register_method("set_string", &TLShapedParagraph::set_string);
 	register_method("get_string", &TLShapedParagraph::get_string);
-	register_property<TLShapedParagraph, Ref<TLShapedAttributedString> >("string", &TLShapedParagraph::set_string, &TLShapedParagraph::get_string, Ref<TLShapedAttributedString>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_NOEDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLShapedAttributedString"));
+	register_property<TLShapedParagraph, Ref<TLShapedAttributedString> >("string", &TLShapedParagraph::set_string, &TLShapedParagraph::get_string, Ref<TLShapedAttributedString>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_EDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLShapedAttributedString"));
 
 	register_method("set_brk_flags", &TLShapedParagraph::set_brk_flags);
 	register_method("get_brk_flags", &TLShapedParagraph::get_brk_flags);

--- a/src/resources/tl_shaped_string.cpp
+++ b/src/resources/tl_shaped_string.cpp
@@ -3117,7 +3117,7 @@ void TLShapedString::_register_methods() {
 
 	register_property<TLShapedString, int>("base_direction", &TLShapedString::set_base_direction, &TLShapedString::get_base_direction, TEXT_DIRECTION_AUTO, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, String("LTR,RTL,Locale,Auto"));
 	register_property<TLShapedString, String>("text", &TLShapedString::set_text, &TLShapedString::get_text, String());
-	register_property<TLShapedString, Ref<TLFontFamily> >("base_font", &TLShapedString::set_base_font, &TLShapedString::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_NOEDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
+	register_property<TLShapedString, Ref<TLFontFamily> >("base_font", &TLShapedString::set_base_font, &TLShapedString::get_base_font, Ref<TLFontFamily>(), GODOT_METHOD_RPC_MODE_DISABLED, (godot_property_usage_flags)(GODOT_PROPERTY_USAGE_EDITOR | GODOT_PROPERTY_USAGE_STORAGE), GODOT_PROPERTY_HINT_RESOURCE_TYPE, String("TLFontFamily"));
 	register_property<TLShapedString, String>("base_font_style", &TLShapedString::set_base_font_style, &TLShapedString::get_base_font_style, String("Regular"));
 	register_property<TLShapedString, int>("base_font_size", &TLShapedString::set_base_font_size, &TLShapedString::get_base_font_size, 12);
 	register_property<TLShapedString, String>("features", &TLShapedString::set_features, &TLShapedString::get_features, String());

--- a/src/tools/tl_font_family_edit.hpp
+++ b/src/tools/tl_font_family_edit.hpp
@@ -13,146 +13,6 @@
 
 /*************************************************************************/
 
-class ButtonAddStyle : public Button {
-	GDCLASS(ButtonAddStyle, Button);
-
-	Ref<TLFontFamily> ff;
-	LineEdit *ctl;
-
-protected:
-	virtual void pressed() {
-		if (ff.is_valid() && ctl && ctl->get_text() != String()) {
-			ff->add_style(ctl->get_text());
-		}
-	}
-
-public:
-	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
-	void set_ctl(LineEdit *p_clt) { ctl = p_clt; };
-
-	ButtonAddStyle() {
-		ctl = NULL;
-	}
-};
-
-/*************************************************************************/
-
-class ButtonDelStyle : public Button {
-	GDCLASS(ButtonDelStyle, Button);
-
-	Ref<TLFontFamily> ff;
-	String sname;
-
-protected:
-	virtual void pressed() {
-		if (ff.is_valid()) {
-			ff->remove_style(sname);
-		}
-	}
-
-public:
-	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
-	void set_sname(const String &p_sname) { sname = p_sname; };
-};
-
-/*************************************************************************/
-
-class ButtonAddScript : public Button {
-	GDCLASS(ButtonAddScript, Button);
-
-	Ref<TLFontFamily> ff;
-	String sname;
-	LineEdit *ctl;
-
-protected:
-	virtual void pressed() {
-		if (ff.is_valid() && ctl && ctl->get_text() != String()) {
-			ff->add_script(sname, ctl->get_text());
-		}
-	}
-
-public:
-	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
-	void set_sname(const String &p_sname) { sname = p_sname; };
-	void set_ctl(LineEdit *p_clt) { ctl = p_clt; };
-
-	ButtonAddScript() {
-		ctl = NULL;
-	}
-};
-
-/*************************************************************************/
-
-class ButtonDelScript : public Button {
-	GDCLASS(ButtonDelScript, Button);
-
-	Ref<TLFontFamily> ff;
-	String sname;
-	String scr;
-
-protected:
-	virtual void pressed() {
-		if (ff.is_valid()) {
-			ff->remove_script(sname, scr);
-		}
-	}
-
-public:
-	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
-	void set_sname(const String &p_sname) { sname = p_sname; };
-	void set_scr(const String &p_scr) { scr = p_scr; };
-};
-
-/*************************************************************************/
-
-class ButtonAddLang : public Button {
-	GDCLASS(ButtonAddLang, Button);
-
-	Ref<TLFontFamily> ff;
-	String sname;
-	LineEdit *ctl;
-
-protected:
-	virtual void pressed() {
-		if (ff.is_valid() && ctl && ctl->get_text() != String()) {
-			ff->add_language(sname, ctl->get_text());
-		}
-	}
-
-public:
-	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
-	void set_sname(const String &p_sname) { sname = p_sname; };
-	void set_ctl(LineEdit *p_clt) { ctl = p_clt; };
-
-	ButtonAddLang() {
-		ctl = NULL;
-	}
-};
-
-/*************************************************************************/
-
-class ButtonDelLang : public Button {
-	GDCLASS(ButtonDelLang, Button);
-
-	Ref<TLFontFamily> ff;
-	String sname;
-	String lang;
-
-protected:
-	virtual void pressed() {
-		if (ff.is_valid()) {
-			ff->remove_language(sname, lang);
-		}
-	}
-
-public:
-	void set_ff(const Ref<TLFontFamily> &p_ff) { ff = p_ff; };
-	void set_sname(const String &p_sname) { sname = p_sname; };
-	void set_lang(const String &p_lang) { lang = p_lang; };
-};
-
-/*************************************************************************/
-
 class TLFontFamilyPreview : public VBoxContainer {
 
 	GDCLASS(TLFontFamilyPreview, VBoxContainer);
@@ -177,6 +37,16 @@ public:
 
 class EditorInspectorPluginTLFontFamily : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorPluginTLFontFamily, EditorInspectorPlugin);
+
+	void _new_style(Object *p_object, Object *p_ctl);
+	void _remove_style(Object *p_object, String p_style);
+	void _new_lang(Object *p_object, String p_style, Object *p_ctl);
+	void _new_script(Object *p_object, String p_style, Object *p_ctl);
+	void _remove_lang(Object *p_object, String p_style, String p_lang);
+	void _remove_script(Object *p_object, String p_style, String p_script);
+
+protected:
+	static void _bind_methods();
 
 public:
 	virtual bool can_handle(Object *p_object);


### PR DESCRIPTION
*Note:* there's bug in the Godot's `EditorInspector`, new resource pop-up doesn't display correct list of supported types (all types derived directly from `Resource` are always shown, the rest are missing), selecting invalid type will cause crash ~and there's impossible to create new `TLBitmapFontFace` and `TLDynamicFontFace` directly from the editor~ (*fixed by setting these to be `Resource` children*).

`ctrls_gdnative` demo updated to use properties instead of loading fonts from code.
![Screenshot 2019-10-30 at 19 17 15](https://user-images.githubusercontent.com/7645683/67882012-35c89400-fb4a-11e9-95c9-28476765ad88.png)
