### PR TITLE
Fix icu build error for android

### DIFF
--- a/subprojects/icu4c/SCsub
+++ b/subprojects/icu4c/SCsub
@@ -161,6 +161,9 @@ env_icu4c.Append(CXXFLAGS=[
 if (not env_icu4c.msvc):
     env_icu4c.Append(CXXFLAGS=["-std=c++11"])
 
+if env["platform"] == 'android':
+    env_icu4c.Append(CXXFLAGS=["-frtti"])
+
 env_icu4c.disable_warnings()
 
 env_thirdparty = env_icu4c.Clone()


### PR DESCRIPTION
godot_tl: master
Godot: 3.2.1 stable
OS: Ubuntu 18.04

Fix these errors:

`modules/godot_tl/subprojects/icu4c/source/common/normalizer2.cpp:347:41: error: use of dynamic_cast requires -frtti
        const Normalizer2WithImpl *n2wi=dynamic_cast<const Normalizer2WithImpl *>(n2);
                                        ^
modules/godot_tl/subprojects/icu4c/source/common/normalizer2.cpp:384:41: error: use of dynamic_cast requires -frtti
        const Normalizer2WithImpl *n2wi=dynamic_cast<const Normalizer2WithImpl *>(n2);`

when building for android:

`scons platform=android target=release android_arch=armv7 -j4`