### PR TITLE
Fix module control issues and export template build.

### DIFF
--- a/.scripts/module_build_3_2_1.sh
+++ b/.scripts/module_build_3_2_1.sh
@@ -15,7 +15,8 @@ fi
 cd godot
 
 git apply ./modules/godot_tl/patch_font_3_2_x.diff
-git apply ./modules/godot_tl/patch_editor_fonts_3_2_1.diff
+git apply ./modules/godot_tl/patch_editor_fonts_3_2_x.diff
+git apply ./modules/godot_tl/patch_dialog_3_2_x.diff
 git apply ./modules/godot_tl/patch_lbl_3_2_x.diff
 git apply ./modules/godot_tl/patch_le_3_2_x.diff
 

--- a/.scripts/module_build_3_2_1_export.sh
+++ b/.scripts/module_build_3_2_1_export.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ev
+
+scons --version
+clang --version
+
+cd ..
+git clone --branch 3.2.1-stable --depth 1 https://github.com/godotengine/godot godot
+
+if [ ! -d $(pwd)/godot/modules/godot_tl ]; then
+	ln -s $(pwd)/godot_tl $(pwd)/godot/modules/godot_tl
+fi
+
+cd godot
+
+git apply ./modules/godot_tl/patch_font_3_2_x.diff
+git apply ./modules/godot_tl/patch_default_theme_3_2_x.diff
+git apply ./modules/godot_tl/patch_dialog_3_2_x.diff
+git apply ./modules/godot_tl/patch_lbl_3_2_x.diff
+git apply ./modules/godot_tl/patch_le_3_2_x.diff
+
+scons -j2 platform=x11 bits=64 target=release tools=no warnings=extra module_hdr_enabled=no module_bmp_enabled=no module_bullet_enabled=no module_jpg_enabled=no module_squish_enabled=no module_csg_enabled=no module_stb_vorbis_enabled=no module_cvtt_enabled=no module_mbedtls_enabled=no module_dds_enabled=no module_tga_enabled=no module_enet_enabled=no module_thekla_unwrap_enabled=no module_etc_enabled=no module_mobile_vr_enabled=no module_theora_enabled=no module_ogg_enabled=no module_upnp_enabled=no module_gdnative_enabled=no module_opensimplex_enabled=no module_opus_enabled=no module_vorbis_enabled=no module_pvr_enabled=no module_webm_enabled=no module_recast_enabled=no module_webp_enabled=no module_websocket_enabled=no module_gridmap_enabled=no module_xatlas_unwrap_enabled=no builtin_freetype=yes builtin_libpng=yes builtin_zlib=yes use_llvm=yes use_font_wrapper=true

--- a/.scripts/module_build_3_2_2.sh
+++ b/.scripts/module_build_3_2_2.sh
@@ -15,7 +15,8 @@ fi
 cd godot
 
 git apply ./modules/godot_tl/patch_font_3_2_x.diff
-git apply ./modules/godot_tl/patch_editor_fonts_3_2_2.diff
+git apply ./modules/godot_tl/patch_editor_fonts_3_2_x.diff
+git apply ./modules/godot_tl/patch_dialog_3_2_x.diff
 git apply ./modules/godot_tl/patch_lbl_3_2_x.diff
 git apply ./modules/godot_tl/patch_le_3_2_x.diff
 

--- a/.scripts/module_build_3_2_2_export.sh
+++ b/.scripts/module_build_3_2_2_export.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ev
+
+scons --version
+clang --version
+
+cd ..
+git clone --branch 3.2 --depth 1 https://github.com/godotengine/godot godot
+
+if [ ! -d $(pwd)/godot/modules/godot_tl ]; then
+	ln -s $(pwd)/godot_tl $(pwd)/godot/modules/godot_tl
+fi
+
+cd godot
+
+git apply ./modules/godot_tl/patch_font_3_2_x.diff
+git apply ./modules/godot_tl/patch_default_theme_3_2_x.diff
+git apply ./modules/godot_tl/patch_dialog_3_2_x.diff
+git apply ./modules/godot_tl/patch_lbl_3_2_x.diff
+git apply ./modules/godot_tl/patch_le_3_2_x.diff
+
+scons -j2 platform=x11 bits=64 target=release tools=no warnings=extra module_hdr_enabled=no module_bmp_enabled=no module_bullet_enabled=no module_jpg_enabled=no module_squish_enabled=no module_csg_enabled=no module_stb_vorbis_enabled=no module_cvtt_enabled=no module_mbedtls_enabled=no module_dds_enabled=no module_tga_enabled=no module_enet_enabled=no module_thekla_unwrap_enabled=no module_etc_enabled=no module_mobile_vr_enabled=no module_theora_enabled=no module_ogg_enabled=no module_upnp_enabled=no module_gdnative_enabled=no module_opensimplex_enabled=no module_opus_enabled=no module_vorbis_enabled=no module_pvr_enabled=no module_webm_enabled=no module_recast_enabled=no module_webp_enabled=no module_websocket_enabled=no module_gridmap_enabled=no module_xatlas_unwrap_enabled=no builtin_freetype=yes builtin_libpng=yes builtin_zlib=yes use_llvm=yes use_font_wrapper=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,19 @@ matrix:
       os: linux
       compiler: clang
 
-    - env: LABEL="Linux module (3.2.2-dev)" GDNATIVE=no GDVER=32
+    - env: LABEL="Linux module (Tools, Debug, 3.2.2-dev)" GDNATIVE=no GDVER=32
       os: linux
       compiler: clang
 
-    - env: LABEL="Linux module (3.2.1-stable)" GDNATIVE=no GDVER=31
+    - env: LABEL="Linux module (Tools, Debug, 3.2.1-stable)" GDNATIVE=no GDVER=31
+      os: linux
+      compiler: clang
+
+    - env: LABEL="Linux module (Export Template, Release, 3.2.2-dev)" GDNATIVE=no GDVER=32e
+      os: linux
+      compiler: clang
+
+    - env: LABEL="Linux module (Export Template, Release, 3.2.1-stable)" GDNATIVE=no GDVER=31e
       os: linux
       compiler: clang
 
@@ -39,6 +47,10 @@ script:
       bash ./.scripts/gdn_build.sh;
     elif [ "$GDVER" = "32" ]; then
       bash ./.scripts/module_build_3_2_2.sh;
-    else
+    elif [ "$GDVER" = "31" ]; then
       bash ./.scripts/module_build_3_2_1.sh;
+    elif [ "$GDVER" = "32e" ]; then
+      bash ./.scripts/module_build_3_2_2_export.sh;
+    elif [ "$GDVER" = "31e" ]; then
+      bash ./.scripts/module_build_3_2_1_export.sh;
     fi

--- a/patch_default_theme_3_2_x.diff
+++ b/patch_default_theme_3_2_x.diff
@@ -1,0 +1,177 @@
+diff --git a/scene/resources/default_theme/SCsub b/scene/resources/default_theme/SCsub
+index b01e2fd54d..3b9c1cdaea 100644
+--- a/scene/resources/default_theme/SCsub
++++ b/scene/resources/default_theme/SCsub
+@@ -2,4 +2,23 @@
+ 
+ Import('env')
+ 
++import os
++import os.path
++from platform_methods import run_in_subprocess
++from compat import open_utf8
++import font_builders
++import glob
++
++path = env.Dir('.').abspath
++
++# Fonts
++flist = glob.glob(path + "/../../../thirdparty/fonts/*.ttf")
++flist.extend(glob.glob(path + "/../../../thirdparty/fonts/*.otf"))
++flist.sort()
++env.Depends('builtin_noto_fonts.gen.h', flist)
++env.CommandNoCache('builtin_noto_fonts.gen.h', flist, run_in_subprocess(font_builders.make_fonts_header))
++
++env.Append(CXXFLAGS=['-DGODOT_MODULE'])
++env.Append(CPPPATH=['#modules/godot_tl/src/resources', '#modules/godot_tl/src', '#modules/godot_tl/subprojects/graphite2/include', '#modules/godot_tl/subprojects/harfbuzz/src', '#modules/godot_tl/subprojects/icu4c/source/common'])
++
+ env.add_source_files(env.scene_sources, "*.cpp")
+diff --git a/scene/resources/default_theme/default_theme.cpp b/scene/resources/default_theme/default_theme.cpp
+index 00c56e5eb2..e144f586a5 100644
+--- a/scene/resources/default_theme/default_theme.cpp
++++ b/scene/resources/default_theme/default_theme.cpp
+@@ -35,8 +35,11 @@
+ #include "core/os/os.h"
+ #include "theme_data.h"
+ 
+-#include "font_hidpi.inc"
+-#include "font_lodpi.inc"
++#include "builtin_noto_fonts.gen.h"
++
++#include "modules/godot_tl/src/resources/tl_font_family.hpp"
++#include "modules/godot_tl/src/resources/tl_dynamic_font.hpp"
++#include "modules/godot_tl/src/resources/tl_gd_font_wrapper.hpp"
+ 
+ typedef Map<const void *, Ref<ImageTexture> > TexCacheMap;
+ 
+@@ -877,10 +880,80 @@ void make_default_theme(bool p_hidpi, Ref<Font> p_font) {
+ 	Ref<Font> default_font;
+ 	if (p_font.is_valid()) {
+ 		default_font = p_font;
+-	} else if (p_hidpi) {
+-		default_font = make_font(_hidpi_font_height, _hidpi_font_ascent, _hidpi_font_charcount, &_hidpi_font_charrects[0][0], _hidpi_font_kerning_pair_count, &_hidpi_font_kerning_pairs[0][0], _hidpi_font_img_width, _hidpi_font_img_height, _hidpi_font_img_data);
+ 	} else {
+-		default_font = make_font(_lodpi_font_height, _lodpi_font_ascent, _lodpi_font_charcount, &_lodpi_font_charrects[0][0], _lodpi_font_kerning_pair_count, &_lodpi_font_kerning_pairs[0][0], _lodpi_font_img_width, _lodpi_font_img_height, _lodpi_font_img_data);
++#ifdef OSX_ENABLED
++		DynamicFaceHinting font_hinting = DF_HINTING_NONE;
++#else
++		DynamicFaceHinting font_hinting = DF_HINTING_LIGHT;
++#endif
++		Ref<TLDynamicFontFace> DefaultFont;
++		DefaultFont.instance();
++		DefaultFont->set_hinting(font_hinting);
++		DefaultFont->set_font_ptr(_font_NotoSansUI_Regular, _font_NotoSansUI_Regular_size);
++		DefaultFont->set_force_autohinter(true); //just looks better..i think?
++
++		Ref<TLDynamicFontFace> DefaultFontBold;
++		DefaultFontBold.instance();
++		DefaultFontBold->set_hinting(font_hinting);
++		DefaultFontBold->set_font_ptr(_font_NotoSansUI_Bold, _font_NotoSansUI_Bold_size);
++		DefaultFontBold->set_force_autohinter(true); // just looks better..i think?
++
++		Ref<TLDynamicFontFace> FontFallback;
++		FontFallback.instance();
++		FontFallback->set_hinting(font_hinting);
++		FontFallback->set_font_ptr(_font_DroidSansFallback, _font_DroidSansFallback_size);
++		FontFallback->set_force_autohinter(true); //just looks better..i think?
++
++		Ref<TLDynamicFontFace> FontJapanese;
++		FontJapanese.instance();
++		FontJapanese->set_hinting(font_hinting);
++		FontJapanese->set_font_ptr(_font_DroidSansJapanese, _font_DroidSansJapanese_size);
++		FontJapanese->set_force_autohinter(true); //just looks better..i think?
++
++		Ref<TLDynamicFontFace> FontArabic;
++		FontArabic.instance();
++		FontArabic->set_hinting(font_hinting);
++		FontArabic->set_font_ptr(_font_NotoNaskhArabicUI_Regular, _font_NotoNaskhArabicUI_Regular_size);
++		FontArabic->set_force_autohinter(true); //just looks better..i think?
++
++		Ref<TLDynamicFontFace> FontHebrew;
++		FontHebrew.instance();
++		FontHebrew->set_hinting(font_hinting);
++		FontHebrew->set_font_ptr(_font_NotoSansHebrew_Regular, _font_NotoSansHebrew_Regular_size);
++		FontHebrew->set_force_autohinter(true); //just looks better..i think?
++
++		Ref<TLDynamicFontFace> FontThai;
++		FontThai.instance();
++		FontThai->set_hinting(font_hinting);
++		FontThai->set_font_ptr(_font_NotoSansThaiUI_Regular, _font_NotoSansThaiUI_Regular_size);
++		FontThai->set_force_autohinter(true); //just looks better..i think?
++
++		Ref<TLDynamicFontFace> FontHindi;
++		FontHindi.instance();
++		FontHindi->set_hinting(font_hinting);
++		FontHindi->set_font_ptr(_font_NotoSansDevanagariUI_Regular, _font_NotoSansDevanagariUI_Regular_size);
++		FontHindi->set_force_autohinter(true); //just looks better..i think?
++
++		Ref<TLFontFamily> dff;
++		dff.instance();
++		dff->add_style("Default");
++		dff->add_style("Bold");
++		dff->add_style("Source");
++		dff->add_face("Default", DefaultFont);
++		dff->add_face("Default", FontArabic);
++		dff->add_face("Default", FontHebrew);
++		dff->add_face("Default", FontThai);
++		dff->add_face("Default", FontHindi);
++		dff->add_face("Default", FontJapanese);
++		dff->add_face("Default", FontFallback);
++
++		Ref<TLGDFontWrapper> df;
++		df.instance();
++		df->set_base_font(dff);
++		df->set_base_font_style("Default");
++		df->set_base_font_size(16);
++
++		default_font = df;
+ 	}
+ 	Ref<Font> large_font = default_font;
+ 	fill_default_theme(t, default_font, large_font, default_icon, default_style, p_hidpi ? 2.0 : 1.0);
+diff --git a/scene/resources/default_theme/font_builders.py b/scene/resources/default_theme/font_builders.py
+new file mode 100644
+index 0000000000..dd78006e53
+--- /dev/null
++++ b/scene/resources/default_theme/font_builders.py
+@@ -0,0 +1,41 @@
++"""Functions used to generate source files during build time
++
++All such functions are invoked in a subprocess on Windows to prevent build flakiness.
++
++"""
++import os
++import os.path
++from platform_methods import subprocess_main
++from compat import encode_utf8, byte_to_str, open_utf8
++
++def make_fonts_header(target, source, env):
++
++    dst = target[0]
++
++    g = open_utf8(dst, "w")
++
++    g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
++    g.write("#ifndef _EDITOR_FONTS_H\n")
++    g.write("#define _EDITOR_FONTS_H\n")
++
++    # saving uncompressed, since freetype will reference from memory pointer
++    xl_names = []
++    for i in range(len(source)):
++        with open(source[i], "rb")as f:
++            buf = f.read()
++
++        name = os.path.splitext(os.path.basename(source[i]))[0]
++
++        g.write("static const int _font_" + name + "_size = " + str(len(buf)) + ";\n")
++        g.write("static const unsigned char _font_" + name + "[] = {\n")
++        for j in range(len(buf)):
++            g.write("\t" + byte_to_str(buf[j]) + ",\n")
++
++        g.write("};\n")
++
++    g.write("#endif")
++
++    g.close()
++
++if __name__ == '__main__':
++    subprocess_main(globals())

--- a/patch_dialog_3_2_x.diff
+++ b/patch_dialog_3_2_x.diff
@@ -1,0 +1,13 @@
+diff --git a/scene/gui/dialogs.cpp b/scene/gui/dialogs.cpp
+index d5e8d04390..b350b94c3f 100644
+--- a/scene/gui/dialogs.cpp
++++ b/scene/gui/dialogs.cpp
+@@ -206,7 +206,7 @@ void WindowDialog::_notification(int p_what) {
+ 			Ref<Font> title_font = get_font("title_font", "WindowDialog");
+ 			Color title_color = get_color("title_color", "WindowDialog");
+ 			int title_height = get_constant("title_height", "WindowDialog");
+-			int font_height = title_font->get_height() - title_font->get_descent() * 2;
++			int font_height = title_font->get_height();
+ 			int x = (size.x - title_font->get_string_size(xl_title).x) / 2;
+ 			int y = (-title_height + font_height) / 2;
+ 			title_font->draw(canvas, Point2(x, y), xl_title, title_color, size.x - panel->get_minimum_size().x);

--- a/patch_editor_fonts_3_2_x.diff
+++ b/patch_editor_fonts_3_2_x.diff
@@ -12,15 +12,19 @@ index 2b560f68e8..0481837354 100644
  
      SConscript('collada/SCsub')
 diff --git a/editor/editor_fonts.cpp b/editor/editor_fonts.cpp
-index 171b7a2176..9dd4b86fe6 100644
+index 171b7a2176..a5f3a9700e 100644
 --- a/editor/editor_fonts.cpp
 +++ b/editor/editor_fonts.cpp
-@@ -35,58 +35,10 @@
+@@ -35,58 +35,31 @@
  #include "editor_scale.h"
  #include "editor_settings.h"
  #include "scene/resources/default_theme/default_theme.h"
 -#include "scene/resources/dynamic_font.h"
--
++#include "scene/resources/theme.h"
++#include "modules/godot_tl/src/resources/tl_font_family.hpp"
++#include "modules/godot_tl/src/resources/tl_dynamic_font.hpp"
++#include "modules/godot_tl/src/resources/tl_gd_font_wrapper.hpp"
+ 
 -#define MAKE_FALLBACKS(m_name)          \
 -	m_name->add_fallback(FontArabic);   \
 -	m_name->add_fallback(FontHebrew);   \
@@ -30,9 +34,10 @@ index 171b7a2176..9dd4b86fe6 100644
 -	m_name->add_fallback(FontFallback);
 -
 -// the custom spacings might only work with Noto Sans
--#define MAKE_DEFAULT_FONT(m_name, m_size)                       \
+ #define MAKE_DEFAULT_FONT(m_name, m_size)                       \
 -	Ref<DynamicFont> m_name;                                    \
--	m_name.instance();                                          \
++	Ref<TLGDFontWrapper> m_name;                                \
+ 	m_name.instance();                                          \
 -	m_name->set_size(m_size);                                   \
 -	if (CustomFont.is_valid()) {                                \
 -		m_name->set_font_data(CustomFont);                      \
@@ -43,10 +48,14 @@ index 171b7a2176..9dd4b86fe6 100644
 -	m_name->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);    \
 -	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE); \
 -	MAKE_FALLBACKS(m_name);
--
--#define MAKE_BOLD_FONT(m_name, m_size)                          \
++	m_name->set_base_font(dff);                                 \
++	m_name->set_base_font_style("Default");                     \
++	m_name->set_base_font_size(m_size);                         \
+ 
+ #define MAKE_BOLD_FONT(m_name, m_size)                          \
 -	Ref<DynamicFont> m_name;                                    \
--	m_name.instance();                                          \
++	Ref<TLGDFontWrapper> m_name;                                \
+ 	m_name.instance();                                          \
 -	m_name->set_size(m_size);                                   \
 -	if (CustomFontBold.is_valid()) {                            \
 -		m_name->set_font_data(CustomFontBold);                  \
@@ -57,10 +66,14 @@ index 171b7a2176..9dd4b86fe6 100644
 -	m_name->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);    \
 -	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE); \
 -	MAKE_FALLBACKS(m_name);
--
--#define MAKE_SOURCE_FONT(m_name, m_size)                        \
++	m_name->set_base_font(dff);                                 \
++	m_name->set_base_font_style("Bold");                        \
++	m_name->set_base_font_size(m_size);                         \
+ 
+ #define MAKE_SOURCE_FONT(m_name, m_size)                        \
 -	Ref<DynamicFont> m_name;                                    \
--	m_name.instance();                                          \
++	Ref<TLGDFontWrapper> m_name;                                \
+ 	m_name.instance();                                          \
 -	m_name->set_size(m_size);                                   \
 -	if (CustomFontSource.is_valid()) {                          \
 -		m_name->set_font_data(CustomFontSource);                \
@@ -71,14 +84,13 @@ index 171b7a2176..9dd4b86fe6 100644
 -	m_name->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);    \
 -	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE); \
 -	MAKE_FALLBACKS(m_name);
-+#include "scene/resources/theme.h"
-+#include "modules/godot_tl/src/resources/tl_font_family.hpp"
-+#include "modules/godot_tl/src/resources/tl_dynamic_font.hpp"
-+#include "modules/godot_tl/src/resources/tl_gd_font_wrapper.hpp"
++	m_name->set_base_font(dff);                                 \
++	m_name->set_base_font_style("Bold");                        \
++	m_name->set_base_font_size(m_size);                         \
  
  void editor_register_fonts(Ref<Theme> p_theme) {
  	DirAccess *dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-@@ -96,7 +48,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
+@@ -96,7 +69,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
  	bool font_antialiased = (bool)EditorSettings::get_singleton()->get("interface/editor/font_antialiased");
  	int font_hinting_setting = (int)EditorSettings::get_singleton()->get("interface/editor/font_hinting");
  
@@ -87,7 +99,7 @@ index 171b7a2176..9dd4b86fe6 100644
  	switch (font_hinting_setting) {
  		case 0:
  			// The "Auto" setting uses the setting that best matches the OS' font rendering:
-@@ -104,27 +56,26 @@ void editor_register_fonts(Ref<Theme> p_theme) {
+@@ -104,27 +77,26 @@ void editor_register_fonts(Ref<Theme> p_theme) {
  			// - Windows uses ClearType, which is in between "Light" and "Normal" hinting.
  			// - Linux has configurable font hinting, but most distributions including Ubuntu default to "Light".
  #ifdef OSX_ENABLED
@@ -121,7 +133,7 @@ index 171b7a2176..9dd4b86fe6 100644
  		CustomFont->set_hinting(font_hinting);
  		CustomFont->set_font_path(custom_font_path);
  		CustomFont->set_force_autohinter(true); //just looks better..i think?
-@@ -135,10 +86,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
+@@ -135,10 +107,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
  	/* Custom Bold font */
  
  	String custom_font_path_bold = EditorSettings::get_singleton()->get("interface/editor/main_font_bold");
@@ -133,7 +145,7 @@ index 171b7a2176..9dd4b86fe6 100644
  		CustomFontBold->set_hinting(font_hinting);
  		CustomFontBold->set_font_path(custom_font_path_bold);
  		CustomFontBold->set_force_autohinter(true); //just looks better..i think?
-@@ -149,10 +99,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
+@@ -149,10 +120,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
  	/* Custom source code font */
  
  	String custom_font_path_source = EditorSettings::get_singleton()->get("interface/editor/code_font");
@@ -145,7 +157,7 @@ index 171b7a2176..9dd4b86fe6 100644
  		CustomFontSource->set_hinting(font_hinting);
  		CustomFontSource->set_font_path(custom_font_path_source);
  	} else {
-@@ -163,113 +112,197 @@ void editor_register_fonts(Ref<Theme> p_theme) {
+@@ -163,72 +133,104 @@ void editor_register_fonts(Ref<Theme> p_theme) {
  
  	/* Droid Sans */
  
@@ -266,114 +278,8 @@ index 171b7a2176..9dd4b86fe6 100644
 +	dff->add_face("Source", FontFallback);
 +
  	// Default font
--	MAKE_DEFAULT_FONT(df, default_font_size);
-+	Ref<TLGDFontWrapper> df;
-+	df.instance();
-+	df->set_base_font(dff);
-+	df->set_base_font_style("Default");
-+	df->set_base_font_size(default_font_size);
+ 	MAKE_DEFAULT_FONT(df, default_font_size);
  	p_theme->set_default_theme_font(df);
- 	p_theme->set_font("main", "EditorFonts", df);
- 
- 	// Bold font
--	MAKE_BOLD_FONT(df_bold, default_font_size);
-+	Ref<TLGDFontWrapper> df_bold;
-+	df_bold.instance();
-+	df_bold->set_base_font(dff);
-+	df_bold->set_base_font_style("Bold");
-+	df_bold->set_base_font_size(default_font_size);
- 	p_theme->set_font("bold", "EditorFonts", df_bold);
- 
- 	// Title font
--	MAKE_BOLD_FONT(df_title, default_font_size + 2 * EDSCALE);
-+	Ref<TLGDFontWrapper> df_title;
-+	df_title.instance();
-+	df_title->set_base_font(dff);
-+	df_title->set_base_font_style("Bold");
-+	df_title->set_base_font_size(default_font_size + 2 * EDSCALE);
- 	p_theme->set_font("title", "EditorFonts", df_title);
- 
- 	// Documentation fonts
--	MAKE_DEFAULT_FONT(df_doc, int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
--	MAKE_BOLD_FONT(df_doc_bold, int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
--	MAKE_BOLD_FONT(df_doc_title, int(EDITOR_GET("text_editor/help/help_title_font_size")) * EDSCALE);
--	MAKE_SOURCE_FONT(df_doc_code, int(EDITOR_GET("text_editor/help/help_source_font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_doc;
-+	df_doc.instance();
-+	df_doc->set_base_font(dff);
-+	df_doc->set_base_font_style("Default");
-+	df_doc->set_base_font_size(int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_doc_bold;
-+	df_doc_bold.instance();
-+	df_doc_bold->set_base_font(dff);
-+	df_doc_bold->set_base_font_style("Bold");
-+	df_doc_bold->set_base_font_size(int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_doc_title;
-+	df_doc_title.instance();
-+	df_doc_title->set_base_font(dff);
-+	df_doc_title->set_base_font_style("Bold");
-+	df_doc_title->set_base_font_size(int(EDITOR_GET("text_editor/help/help_title_font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_doc_code;
-+	df_doc_code.instance();
-+	df_doc_code->set_base_font(dff);
-+	df_doc_code->set_base_font_style("Source");
-+	df_doc_code->set_base_font_size(int(EDITOR_GET("text_editor/help/help_source_font_size")) * EDSCALE);
- 	p_theme->set_font("doc", "EditorFonts", df_doc);
- 	p_theme->set_font("doc_bold", "EditorFonts", df_doc_bold);
- 	p_theme->set_font("doc_title", "EditorFonts", df_doc_title);
- 	p_theme->set_font("doc_source", "EditorFonts", df_doc_code);
- 
- 	// Ruler font
--	MAKE_DEFAULT_FONT(df_rulers, 8 * EDSCALE);
-+	Ref<TLGDFontWrapper> df_rulers;
-+	df_rulers.instance();
-+	df_rulers->set_base_font(dff);
-+	df_rulers->set_base_font_style("Default");
-+	df_rulers->set_base_font_size(8 * EDSCALE);
- 	p_theme->set_font("rulers", "EditorFonts", df_rulers);
- 
- 	// Rotation widget font
--	MAKE_DEFAULT_FONT(df_rotation_control, 14 * EDSCALE);
-+	Ref<TLGDFontWrapper> df_rotation_control;
-+	df_rotation_control.instance();
-+	df_rotation_control->set_base_font(dff);
-+	df_rotation_control->set_base_font_style("Default");
-+	df_rotation_control->set_base_font_size(14 * EDSCALE);
- 	p_theme->set_font("rotation_control", "EditorFonts", df_rotation_control);
- 
- 	// Code font
--	MAKE_SOURCE_FONT(df_code, int(EDITOR_GET("interface/editor/code_font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_code;
-+	df_code.instance();
-+	df_code->set_base_font(dff);
-+	df_code->set_base_font_style("Source");
-+	df_code->set_base_font_size(int(EDITOR_GET("interface/editor/code_font_size")) * EDSCALE);
- 	p_theme->set_font("source", "EditorFonts", df_code);
- 
--	MAKE_SOURCE_FONT(df_expression, (int(EDITOR_GET("interface/editor/code_font_size")) - 1) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_expression;
-+	df_expression.instance();
-+	df_expression->set_base_font(dff);
-+	df_expression->set_base_font_style("Source");
-+	df_expression->set_base_font_size((int(EDITOR_GET("interface/editor/code_font_size")) - 1) * EDSCALE);
- 	p_theme->set_font("expression", "EditorFonts", df_expression);
- 
--	MAKE_SOURCE_FONT(df_output_code, int(EDITOR_GET("run/output/font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_output_code;
-+	df_output_code.instance();
-+	df_output_code->set_base_font(dff);
-+	df_output_code->set_base_font_style("Source");
-+	df_output_code->set_base_font_size(int(EDITOR_GET("run/output/font_size")) * EDSCALE);
- 	p_theme->set_font("output_source", "EditorFonts", df_output_code);
- 
--	MAKE_SOURCE_FONT(df_text_editor_status_code, default_font_size);
-+	Ref<TLGDFontWrapper> df_text_editor_status_code;
-+	df_text_editor_status_code.instance();
-+	df_text_editor_status_code->set_base_font(dff);
-+	df_text_editor_status_code->set_base_font_style("Source");
-+	df_text_editor_status_code->set_base_font_size(default_font_size);
- 	p_theme->set_font("status_source", "EditorFonts", df_text_editor_status_code);
- }
 diff --git a/editor/editor_settings.cpp b/editor/editor_settings.cpp
 index 92e3f61ca5..98fc6d5742 100644
 --- a/editor/editor_settings.cpp

--- a/patch_editor_fonts_4_0_0.diff
+++ b/patch_editor_fonts_4_0_0.diff
@@ -2,25 +2,29 @@ diff --git a/editor/SCsub b/editor/SCsub
 index 2b560f68e8..0481837354 100644
 --- a/editor/SCsub
 +++ b/editor/SCsub
-@@ -78,6 +78,8 @@ if env['tools']:
-     env.Depends('#editor/builtin_fonts.gen.h', flist)
-     env.CommandNoCache('#editor/builtin_fonts.gen.h', flist, run_in_subprocess(editor_builders.make_fonts_header))
+@@ -86,6 +86,8 @@ if env['tools']:
+     env.Depends("#editor/builtin_fonts.gen.h", flist)
+     env.CommandNoCache("#editor/builtin_fonts.gen.h", flist, run_in_subprocess(editor_builders.make_fonts_header))
  
 +    env.Append(CXXFLAGS=['-DGODOT_MODULE'])
 +    env.Append(CPPPATH=['#modules/godot_tl/src/resources', '#modules/godot_tl/src', '#modules/godot_tl/subprojects/graphite2/include', '#modules/godot_tl/subprojects/harfbuzz/src', '#modules/godot_tl/subprojects/icu4c/source/common'])
      env.add_source_files(env.editor_sources, "*.cpp")
  
-     SConscript('collada/SCsub')
+     SConscript("debugger/SCsub")
 diff --git a/editor/editor_fonts.cpp b/editor/editor_fonts.cpp
-index db2f9c53d9..0013299fec 100644
+index 171b7a2176..a5f3a9700e 100644
 --- a/editor/editor_fonts.cpp
 +++ b/editor/editor_fonts.cpp
-@@ -35,58 +35,10 @@
+@@ -35,58 +35,31 @@
  #include "editor_scale.h"
  #include "editor_settings.h"
  #include "scene/resources/default_theme/default_theme.h"
 -#include "scene/resources/dynamic_font.h"
--
++#include "scene/resources/theme.h"
++#include "modules/godot_tl/src/resources/tl_font_family.hpp"
++#include "modules/godot_tl/src/resources/tl_dynamic_font.hpp"
++#include "modules/godot_tl/src/resources/tl_gd_font_wrapper.hpp"
+ 
 -#define MAKE_FALLBACKS(m_name)          \
 -	m_name->add_fallback(FontArabic);   \
 -	m_name->add_fallback(FontHebrew);   \
@@ -30,9 +34,10 @@ index db2f9c53d9..0013299fec 100644
 -	m_name->add_fallback(FontFallback);
 -
 -// the custom spacings might only work with Noto Sans
--#define MAKE_DEFAULT_FONT(m_name, m_size)                       \
+ #define MAKE_DEFAULT_FONT(m_name, m_size)                       \
 -	Ref<DynamicFont> m_name;                                    \
--	m_name.instance();                                          \
++	Ref<TLGDFontWrapper> m_name;                                \
+ 	m_name.instance();                                          \
 -	m_name->set_size(m_size);                                   \
 -	if (CustomFont.is_valid()) {                                \
 -		m_name->set_font_data(CustomFont);                      \
@@ -43,10 +48,14 @@ index db2f9c53d9..0013299fec 100644
 -	m_name->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);    \
 -	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE); \
 -	MAKE_FALLBACKS(m_name);
--
--#define MAKE_BOLD_FONT(m_name, m_size)                          \
++	m_name->set_base_font(dff);                                 \
++	m_name->set_base_font_style("Default");                     \
++	m_name->set_base_font_size(m_size);                         \
+ 
+ #define MAKE_BOLD_FONT(m_name, m_size)                          \
 -	Ref<DynamicFont> m_name;                                    \
--	m_name.instance();                                          \
++	Ref<TLGDFontWrapper> m_name;                                \
+ 	m_name.instance();                                          \
 -	m_name->set_size(m_size);                                   \
 -	if (CustomFontBold.is_valid()) {                            \
 -		m_name->set_font_data(CustomFontBold);                  \
@@ -57,10 +66,14 @@ index db2f9c53d9..0013299fec 100644
 -	m_name->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);    \
 -	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE); \
 -	MAKE_FALLBACKS(m_name);
--
--#define MAKE_SOURCE_FONT(m_name, m_size)                        \
++	m_name->set_base_font(dff);                                 \
++	m_name->set_base_font_style("Bold");                        \
++	m_name->set_base_font_size(m_size);                         \
+ 
+ #define MAKE_SOURCE_FONT(m_name, m_size)                        \
 -	Ref<DynamicFont> m_name;                                    \
--	m_name.instance();                                          \
++	Ref<TLGDFontWrapper> m_name;                                \
+ 	m_name.instance();                                          \
 -	m_name->set_size(m_size);                                   \
 -	if (CustomFontSource.is_valid()) {                          \
 -		m_name->set_font_data(CustomFontSource);                \
@@ -71,14 +84,13 @@ index db2f9c53d9..0013299fec 100644
 -	m_name->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);    \
 -	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE); \
 -	MAKE_FALLBACKS(m_name);
-+#include "scene/resources/theme.h"
-+#include "modules/godot_tl/src/resources/tl_font_family.hpp"
-+#include "modules/godot_tl/src/resources/tl_dynamic_font.hpp"
-+#include "modules/godot_tl/src/resources/tl_gd_font_wrapper.hpp"
++	m_name->set_base_font(dff);                                 \
++	m_name->set_base_font_style("Bold");                        \
++	m_name->set_base_font_size(m_size);                         \
  
  void editor_register_fonts(Ref<Theme> p_theme) {
  	DirAccess *dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-@@ -96,7 +48,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
+@@ -96,7 +69,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
  	bool font_antialiased = (bool)EditorSettings::get_singleton()->get("interface/editor/font_antialiased");
  	int font_hinting_setting = (int)EditorSettings::get_singleton()->get("interface/editor/font_hinting");
  
@@ -87,7 +99,7 @@ index db2f9c53d9..0013299fec 100644
  	switch (font_hinting_setting) {
  		case 0:
  			// The "Auto" setting uses the setting that best matches the OS' font rendering:
-@@ -104,27 +56,26 @@ void editor_register_fonts(Ref<Theme> p_theme) {
+@@ -104,27 +77,26 @@ void editor_register_fonts(Ref<Theme> p_theme) {
  			// - Windows uses ClearType, which is in between "Light" and "Normal" hinting.
  			// - Linux has configurable font hinting, but most distributions including Ubuntu default to "Light".
  #ifdef OSX_ENABLED
@@ -121,7 +133,7 @@ index db2f9c53d9..0013299fec 100644
  		CustomFont->set_hinting(font_hinting);
  		CustomFont->set_font_path(custom_font_path);
  		CustomFont->set_force_autohinter(true); //just looks better..i think?
-@@ -135,10 +86,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
+@@ -135,10 +107,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
  	/* Custom Bold font */
  
  	String custom_font_path_bold = EditorSettings::get_singleton()->get("interface/editor/main_font_bold");
@@ -133,7 +145,7 @@ index db2f9c53d9..0013299fec 100644
  		CustomFontBold->set_hinting(font_hinting);
  		CustomFontBold->set_font_path(custom_font_path_bold);
  		CustomFontBold->set_force_autohinter(true); //just looks better..i think?
-@@ -149,10 +99,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
+@@ -149,10 +120,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
  	/* Custom source code font */
  
  	String custom_font_path_source = EditorSettings::get_singleton()->get("interface/editor/code_font");
@@ -145,7 +157,7 @@ index db2f9c53d9..0013299fec 100644
  		CustomFontSource->set_hinting(font_hinting);
  		CustomFontSource->set_font_path(custom_font_path_source);
  	} else {
-@@ -163,109 +112,189 @@ void editor_register_fonts(Ref<Theme> p_theme) {
+@@ -163,72 +133,104 @@ void editor_register_fonts(Ref<Theme> p_theme) {
  
  	/* Droid Sans */
  
@@ -266,105 +278,8 @@ index db2f9c53d9..0013299fec 100644
 +	dff->add_face("Source", FontFallback);
 +
  	// Default font
--	MAKE_DEFAULT_FONT(df, default_font_size);
-+	Ref<TLGDFontWrapper> df;
-+	df.instance();
-+	df->set_base_font(dff);
-+	df->set_base_font_style("Default");
-+	df->set_base_font_size(default_font_size);
- 	p_theme->set_default_theme_font(df);
- 	p_theme->set_font("main", "EditorFonts", df);
- 
- 	// Bold font
--	MAKE_BOLD_FONT(df_bold, default_font_size);
-+	Ref<TLGDFontWrapper> df_bold;
-+	df_bold.instance();
-+	df_bold->set_base_font(dff);
-+	df_bold->set_base_font_style("Bold");
-+	df_bold->set_base_font_size(default_font_size);
- 	p_theme->set_font("bold", "EditorFonts", df_bold);
- 
- 	// Title font
--	MAKE_BOLD_FONT(df_title, default_font_size + 2 * EDSCALE);
-+	Ref<TLGDFontWrapper> df_title;
-+	df_title.instance();
-+	df_title->set_base_font(dff);
-+	df_title->set_base_font_style("Bold");
-+	df_title->set_base_font_size(default_font_size + 2 * EDSCALE);
- 	p_theme->set_font("title", "EditorFonts", df_title);
- 
- 	// Documentation fonts
--	MAKE_DEFAULT_FONT(df_doc, int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
--	MAKE_BOLD_FONT(df_doc_bold, int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
--	MAKE_BOLD_FONT(df_doc_title, int(EDITOR_GET("text_editor/help/help_title_font_size")) * EDSCALE);
--	MAKE_SOURCE_FONT(df_doc_code, int(EDITOR_GET("text_editor/help/help_source_font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_doc;
-+	df_doc.instance();
-+	df_doc->set_base_font(dff);
-+	df_doc->set_base_font_style("Default");
-+	df_doc->set_base_font_size(int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_doc_bold;
-+	df_doc_bold.instance();
-+	df_doc_bold->set_base_font(dff);
-+	df_doc_bold->set_base_font_style("Bold");
-+	df_doc_bold->set_base_font_size(int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_doc_title;
-+	df_doc_title.instance();
-+	df_doc_title->set_base_font(dff);
-+	df_doc_title->set_base_font_style("Bold");
-+	df_doc_title->set_base_font_size(int(EDITOR_GET("text_editor/help/help_title_font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_doc_code;
-+	df_doc_code.instance();
-+	df_doc_code->set_base_font(dff);
-+	df_doc_code->set_base_font_style("Source");
-+	df_doc_code->set_base_font_size(int(EDITOR_GET("text_editor/help/help_source_font_size")) * EDSCALE);
- 	p_theme->set_font("doc", "EditorFonts", df_doc);
- 	p_theme->set_font("doc_bold", "EditorFonts", df_doc_bold);
- 	p_theme->set_font("doc_title", "EditorFonts", df_doc_title);
- 	p_theme->set_font("doc_source", "EditorFonts", df_doc_code);
- 
- 	// Ruler font
--	MAKE_DEFAULT_FONT(df_rulers, 8 * EDSCALE);
-+	Ref<TLGDFontWrapper> df_rulers;
-+	df_rulers.instance();
-+	df_rulers->set_base_font(dff);
-+	df_rulers->set_base_font_style("Default");
-+	df_rulers->set_base_font_size(8 * EDSCALE);
- 	p_theme->set_font("rulers", "EditorFonts", df_rulers);
- 
- 	// Code font
--	MAKE_SOURCE_FONT(df_code, int(EDITOR_GET("interface/editor/code_font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_code;
-+	df_code.instance();
-+	df_code->set_base_font(dff);
-+	df_code->set_base_font_style("Source");
-+	df_code->set_base_font_size(int(EDITOR_GET("interface/editor/code_font_size")) * EDSCALE);
- 	p_theme->set_font("source", "EditorFonts", df_code);
- 
--	MAKE_SOURCE_FONT(df_expression, (int(EDITOR_GET("interface/editor/code_font_size")) - 1) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_expression;
-+	df_expression.instance();
-+	df_expression->set_base_font(dff);
-+	df_expression->set_base_font_style("Source");
-+	df_expression->set_base_font_size((int(EDITOR_GET("interface/editor/code_font_size")) - 1) * EDSCALE);
- 	p_theme->set_font("expression", "EditorFonts", df_expression);
- 
--	MAKE_SOURCE_FONT(df_output_code, int(EDITOR_GET("run/output/font_size")) * EDSCALE);
-+	Ref<TLGDFontWrapper> df_output_code;
-+	df_output_code.instance();
-+	df_output_code->set_base_font(dff);
-+	df_output_code->set_base_font_style("Source");
-+	df_output_code->set_base_font_size(int(EDITOR_GET("run/output/font_size")) * EDSCALE);
- 	p_theme->set_font("output_source", "EditorFonts", df_output_code);
- 
--	MAKE_SOURCE_FONT(df_text_editor_status_code, default_font_size);
-+	Ref<TLGDFontWrapper> df_text_editor_status_code;
-+	df_text_editor_status_code.instance();
-+	df_text_editor_status_code->set_base_font(dff);
-+	df_text_editor_status_code->set_base_font_style("Source");
-+	df_text_editor_status_code->set_base_font_size(default_font_size);
- 	p_theme->set_font("status_source", "EditorFonts", df_text_editor_status_code);
- }
+ 	MAKE_DEFAULT_FONT(df, default_font_size);
+ 	p_theme->set_font("font", "Node", df); // Default theme font
 diff --git a/editor/editor_settings.cpp b/editor/editor_settings.cpp
 index 92e3f61ca5..98fc6d5742 100644
 --- a/editor/editor_settings.cpp

--- a/patch_lbl_4_0_.diff
+++ b/patch_lbl_4_0_.diff
@@ -1,0 +1,61 @@
+diff --git a/scene/gui/label.cpp b/scene/gui/label.cpp
+index 9b542cb179..1fed2d0d1e 100644
+--- a/scene/gui/label.cpp
++++ b/scene/gui/label.cpp
+@@ -28,6 +28,8 @@
+ /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+ /*************************************************************************/
+ 
++#if 0
++
+ #include "label.h"
+ #include "core/print_string.h"
+ #include "core/project_settings.h"
+@@ -723,3 +725,5 @@ Label::~Label() {
+ 		memdelete(current);
+ 	}
+ }
++
++#endif
+diff --git a/scene/gui/label.h b/scene/gui/label.h
+index ba6e627c58..eec4937166 100644
+--- a/scene/gui/label.h
++++ b/scene/gui/label.h
+@@ -31,6 +31,31 @@
+ #ifndef LABEL_H
+ #define LABEL_H
+ 
++#include "modules/godot_tl/src/controls/tl_label.hpp"
++#include "modules/godot_tl/src/resources/tl_gd_font_wrapper.hpp"
++
++class Label : public TLLabel {
++	GDCLASS(Label, TLLabel);
++public:
++	void _notification(int p_what) {
++		if ((p_what == NOTIFICATION_THEME_CHANGED) || (p_what == NOTIFICATION_POST_ENTER_TREE)) {
++			Ref<Font> font_w = get_theme_font("font");
++			TLGDFontWrapper *fw_ref = cast_to<TLGDFontWrapper>(*font_w);
++			if (fw_ref) {
++				set_base_font(fw_ref->get_base_font());
++				set_base_font_style(fw_ref->get_base_font_style());
++				set_base_font_size(fw_ref->get_base_font_size());
++			}
++		}
++	};
++	Label(const String &p_text = String()) {
++		_init();
++		set_text(p_text);
++	}
++};
++
++#if 0
++
+ #include "scene/gui/control.h"
+ 
+ class Label : public Control {
+@@ -149,3 +174,5 @@ VARIANT_ENUM_CAST(Label::Align);
+ VARIANT_ENUM_CAST(Label::VAlign);
+ 
+ #endif
++
++#endif

--- a/patch_le_4_0_0.diff
+++ b/patch_le_4_0_0.diff
@@ -1,0 +1,95 @@
+diff --git a/scene/gui/line_edit.cpp b/scene/gui/line_edit.cpp
+index 7cc47d351e..2156edb911 100644
+--- a/scene/gui/line_edit.cpp
++++ b/scene/gui/line_edit.cpp
+@@ -28,6 +28,8 @@
+ /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+ /*************************************************************************/
+ 
++#if 0
++
+ #include "line_edit.h"
+ 
+ #include "core/message_queue.h"
+@@ -1878,3 +1880,5 @@ LineEdit::LineEdit() {
+ 
+ LineEdit::~LineEdit() {
+ }
++
++#endif
+diff --git a/scene/gui/line_edit.h b/scene/gui/line_edit.h
+index 037238d682..961411b5ec 100644
+--- a/scene/gui/line_edit.h
++++ b/scene/gui/line_edit.h
+@@ -31,6 +31,31 @@
+ #ifndef LINE_EDIT_H
+ #define LINE_EDIT_H
+ 
++#include "modules/godot_tl/src/controls/tl_line_edit.hpp"
++#include "modules/godot_tl/src/resources/tl_gd_font_wrapper.hpp"
++
++class LineEdit : public TLLineEdit {
++	GDCLASS(LineEdit, TLLineEdit);
++public:
++	void _notification(int p_what) {
++		if ((p_what == NOTIFICATION_THEME_CHANGED) || (p_what == NOTIFICATION_POST_ENTER_TREE)) {
++			Ref<Font> font_w = get_theme_font("font");
++			TLGDFontWrapper *fw_ref = cast_to<TLGDFontWrapper>(*font_w);
++			if (fw_ref) {
++				set_base_font(fw_ref->get_base_font());
++				set_base_font_style(fw_ref->get_base_font_style());
++				set_base_font_size(fw_ref->get_base_font_size());
++			}
++		}
++	}
++
++	LineEdit() {
++		_init();
++	}
++};
++
++#if 0
++
+ #include "scene/gui/control.h"
+ #include "scene/gui/popup_menu.h"
+ 
+@@ -244,3 +269,5 @@ VARIANT_ENUM_CAST(LineEdit::Align);
+ VARIANT_ENUM_CAST(LineEdit::MenuItems);
+ 
+ #endif
++
++#endif
+diff --git a/scene/gui/spin_box.cpp b/scene/gui/spin_box.cpp
+index 92377949f8..93cc621dfa 100644
+--- a/scene/gui/spin_box.cpp
++++ b/scene/gui/spin_box.cpp
+@@ -218,12 +218,12 @@ void SpinBox::_notification(int p_what) {
+ 	}
+ }
+ 
+-void SpinBox::set_align(LineEdit::Align p_align) {
++void SpinBox::set_align(int p_align) {
+ 
+ 	line_edit->set_align(p_align);
+ }
+ 
+-LineEdit::Align SpinBox::get_align() const {
++int SpinBox::get_align() const {
+ 
+ 	return line_edit->get_align();
+ }
+diff --git a/scene/gui/spin_box.h b/scene/gui/spin_box.h
+index 04491c8477..5ba31ece9f 100644
+--- a/scene/gui/spin_box.h
++++ b/scene/gui/spin_box.h
+@@ -76,8 +76,8 @@ public:
+ 
+ 	virtual Size2 get_minimum_size() const;
+ 
+-	void set_align(LineEdit::Align p_align);
+-	LineEdit::Align get_align() const;
++	void set_align(int p_align);
++	int get_align() const;
+ 
+ 	void set_editable(bool p_editable);
+ 	bool is_editable() const;

--- a/src/controls/tl_label.cpp
+++ b/src/controls/tl_label.cpp
@@ -116,12 +116,15 @@ void TLLabel::_notification(int p_what) {
 		Size2 string_size;
 		Size2 size = get_size();
 #ifdef GODOT_MODULE
-		Ref<StyleBox> style = get_stylebox("normal", "Label");
-		Color font_color = get_color("font_color", "Label");
-		Color font_color_shadow = get_color("font_color_shadow", "Label");
-		bool use_outline = get_constant("shadow_as_outline", "Label");
-		Point2 shadow_ofs(get_constant("shadow_offset_x", "Label"), get_constant("shadow_offset_y", "Label"));
-		int line_spacing = get_constant("line_spacing", "Label");
+		StringName cname = get_class_name();
+		if (cname == "TLLabel") cname = "Label";
+
+		Ref<StyleBox> style = get_stylebox("normal", cname);
+		Color font_color = get_color("font_color", cname);
+		Color font_color_shadow = get_color("font_color_shadow", cname);
+		bool use_outline = get_constant("shadow_as_outline", cname);
+		Point2 shadow_ofs(get_constant("shadow_offset_x", cname), get_constant("shadow_offset_y", cname));
+		int line_spacing = get_constant("line_spacing", cname);
 #else
 		Ref<Theme> theme = get_theme();
 		if (theme.is_null()) {
@@ -229,7 +232,10 @@ void TLLabel::_notification(int p_what) {
 
 Size2 TLLabel::get_minimum_size() const {
 #ifdef GODOT_MODULE
-	Size2 min_style = get_stylebox("normal", "Label")->get_minimum_size();
+	StringName cname = get_class_name();
+	if (cname == "TLLabel") cname = "Label";
+
+	Size2 min_style = get_stylebox("normal", cname)->get_minimum_size();
 #else
 	Ref<Theme> theme = get_theme();
 	if (theme.is_null()) {
@@ -264,8 +270,14 @@ int TLLabel::get_line_count() const {
 }
 
 int TLLabel::get_visible_line_count() const {
+#ifdef GODOT_MODULE
+	StringName cname = get_class_name();
+	if (cname == "TLLabel") cname = "Label";
 
+	int line_spacing = get_constant("line_spacing", cname);
+#else
 	int line_spacing = get_constant("line_spacing", "Label");
+#endif
 
 	if (_lines_dirty)
 		const_cast<TLLabel *>(this)->_reshape_lines();
@@ -275,7 +287,7 @@ int TLLabel::get_visible_line_count() const {
 	for (int64_t i = lines_skipped; i < (int64_t)s_lines.size(); i++) {
 		total_h += s_lines[i]->get_height() + line_spacing;
 #ifdef GODOT_MODULE
-		if (total_h > (get_size().height - get_stylebox("normal", "Label")->get_minimum_size().height + line_spacing)) {
+		if (total_h > (get_size().height - get_stylebox("normal", cname)->get_minimum_size().height + line_spacing)) {
 			break;
 		}
 #else
@@ -303,8 +315,11 @@ int TLLabel::get_visible_line_count() const {
 void TLLabel::_reshape_lines() {
 
 #ifdef GODOT_MODULE
-	Ref<StyleBox> style = get_stylebox("normal", "Label");
-	int line_spacing = get_constant("line_spacing", "Label");
+	StringName cname = get_class_name();
+	if (cname == "TLLabel") cname = "Label";
+
+	Ref<StyleBox> style = get_stylebox("normal", cname);
+	int line_spacing = get_constant("line_spacing", cname);
 #else
 	Ref<Theme> theme = get_theme();
 	if (theme.is_null()) {

--- a/src/controls/tl_line_edit.cpp
+++ b/src/controls/tl_line_edit.cpp
@@ -707,7 +707,10 @@ bool TLLineEdit::_is_over_clear_button(const Point2 &p_pos) const {
 	}
 	Ref<Texture> icon = Control::get_icon("clear");
 #ifdef GODOT_MODULE
-	int x_ofs = get_stylebox("normal", "LineEdit")->get_offset().x;
+	StringName cname = get_class_name();
+	if (cname == "TLLineEdit") cname = "LineEdit";
+
+	int x_ofs = get_stylebox("normal", cname)->get_offset().x;
 #else
 	int x_ofs = 0;
 #endif
@@ -765,7 +768,10 @@ void TLLineEdit::_notification(int p_what) {
 			RID ci = get_canvas_item();
 
 #ifdef GODOT_MODULE
-			Ref<StyleBox> style = get_stylebox("normal", "LineEdit");
+			StringName cname = get_class_name();
+			if (cname == "TLLineEdit") cname = "LineEdit";
+
+			Ref<StyleBox> style = get_stylebox("normal", cname);
 #else
 			Ref<Theme> theme = get_theme();
 			if (theme.is_null()) {
@@ -777,7 +783,7 @@ void TLLineEdit::_notification(int p_what) {
 			float disabled_alpha = 1.0; // used to set the disabled input text color
 			if (!is_editable()) {
 #ifdef GODOT_MODULE
-				style = get_stylebox("read_only", "LineEdit");
+				style = get_stylebox("read_only", cname);
 #else
 				style = theme->get_stylebox("read_only", "LineEdit");
 #endif
@@ -817,10 +823,10 @@ void TLLineEdit::_notification(int p_what) {
 			int y_ofs = style->get_offset().y + (y_area - MAX(_get_base_font_height(), line->get_height())) / 2;
 
 #ifdef GODOT_MODULE
-			Color selection_color = get_color("selection_color", "LineEdit");
-			Color font_color = get_color("font_color", "LineEdit");
-			Color font_color_selected = get_color("font_color_selected", "LineEdit");
-			Color cursor_color = get_color("cursor_color", "LineEdit");
+			Color selection_color = get_color("selection_color", cname);
+			Color font_color = get_color("font_color", cname);
+			Color font_color_selected = get_color("font_color_selected", cname);
+			Color cursor_color = get_color("cursor_color", cname);
 #else
 			Color selection_color = theme->get_color("selection_color", "LineEdit");
 			Color font_color = theme->get_color("font_color", "LineEdit");
@@ -838,11 +844,19 @@ void TLLineEdit::_notification(int p_what) {
 				Ref<Texture> r_icon = display_clear_icon ? Control::get_icon("clear") : right_icon;
 				Color color_icon(1, 1, 1, disabled_alpha * .9);
 				if (display_clear_icon) {
+#ifdef GODOT_MODULE
+					if (clear_button_status.press_attempt && clear_button_status.pressing_inside) {
+						color_icon = get_color("clear_button_color_pressed", cname);
+					} else {
+						color_icon = get_color("clear_button_color", cname);
+					}
+#else
 					if (clear_button_status.press_attempt && clear_button_status.pressing_inside) {
 						color_icon = get_color("clear_button_color_pressed", "LineEdit");
 					} else {
 						color_icon = get_color("clear_button_color", "LineEdit");
 					}
+#endif
 				}
 				r_icon->draw(ci, Point2(width - r_icon->get_width() - style->get_margin(GLOBAL_CONST(MARGIN_RIGHT)), height / 2 - r_icon->get_height() / 2), color_icon);
 
@@ -1081,7 +1095,10 @@ void TLLineEdit::shift_selection_check_post(bool p_shift) {
 void TLLineEdit::set_cursor_at_pixel_pos(int p_x) {
 
 #ifdef GODOT_MODULE
-	Ref<StyleBox> style = get_stylebox("normal", "LineEdit");
+	StringName cname = get_class_name();
+	if (cname == "TLLineEdit") cname = "LineEdit";
+
+	Ref<StyleBox> style = get_stylebox("normal", cname);
 #else
 	Ref<Theme> theme = get_theme();
 	if (theme.is_null()) {
@@ -1288,7 +1305,10 @@ float TLLineEdit::get_placeholder_alpha() const {
 void TLLineEdit::set_cursor_position(int p_pos) {
 
 #ifdef GODOT_MODULE
-	Ref<StyleBox> style = get_stylebox("normal", "LineEdit");
+	StringName cname = get_class_name();
+	if (cname == "TLLineEdit") cname = "LineEdit";
+
+	Ref<StyleBox> style = get_stylebox("normal", cname);
 #else
 	Ref<Theme> theme = get_theme();
 	if (theme.is_null()) {
@@ -1392,7 +1412,10 @@ void TLLineEdit::clear_internal() {
 Size2 TLLineEdit::get_minimum_size() const {
 
 #ifdef GODOT_MODULE
-	Ref<StyleBox> style = get_stylebox("normal", "LineEdit");
+	StringName cname = get_class_name();
+	if (cname == "TLLineEdit") cname = "LineEdit";
+
+	Ref<StyleBox> style = get_stylebox("normal", cname);
 #else
 	Ref<Theme> theme = get_theme();
 	if (theme.is_null()) {
@@ -1406,7 +1429,11 @@ Size2 TLLineEdit::get_minimum_size() const {
 
 	//minimum size of text
 	int space_size = 10;
+#ifdef GODOT_MODULE
+	int mstext = get_constant("minimum_spaces", cname) * space_size;
+#else
 	int mstext = get_constant("minimum_spaces", "LineEdit") * space_size;
+#endif
 
 	if (expand_to_text_length) {
 		mstext = line->get_width();

--- a/src/resources/tl_gd_font_wrapper.cpp
+++ b/src/resources/tl_gd_font_wrapper.cpp
@@ -121,7 +121,7 @@ float TLGDFontWrapper::get_ascent() const {
 			return _font->get_ascent(fsize);
 		}
 	}
-	return 15.0f;
+	return 10.0f;
 }
 
 float TLGDFontWrapper::get_descent() const {
@@ -135,7 +135,7 @@ float TLGDFontWrapper::get_descent() const {
 			return _font->get_ascent(fsize);
 		}
 	}
-	return 15.0f;
+	return 5.0f;
 }
 
 Size2 TLGDFontWrapper::get_char_size(CharType p_char, CharType p_next) const {
@@ -165,7 +165,7 @@ Size2 TLGDFontWrapper::get_string_size(const String &p_text) const {
 			sids.pop_front();
 		}
 	}
-	return Size2(str->get_width(), str->get_height());
+	return Size2(str->get_width(), MAX(str->get_height(), get_height()));
 }
 
 void TLGDFontWrapper::draw(RID p_canvas_item, const Point2 &p_pos, const String &p_text, const Color &p_modulate, int p_clip_w, const Color &p_outline_modulate) const {
@@ -190,7 +190,12 @@ void TLGDFontWrapper::draw(RID p_canvas_item, const Point2 &p_pos, const String 
 			sids.pop_front();
 		}
 	}
-	str->draw(p_canvas_item, p_pos, p_modulate);
+	float w = 0.f;
+	for (int i = 0; i < str->clusters(); i++) {
+		if (p_clip_w <= 0.f || (w + str->get_cluster_width(i)) <= p_clip_w) {
+			w += str->draw_cluster(p_canvas_item, Point2(p_pos.x + w, p_pos.y), i, p_modulate).x;
+		}
+	}
 }
 
 float TLGDFontWrapper::draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, bool p_outline) const {


### PR DESCRIPTION
Fix sub-classed wrapper controls themes. Fixes #30
Fix wrapper font clipping. Fixes #29
Add export template default theme font wrapper patch (uses editor fonts). Fixes #31
Add export templates to CI.